### PR TITLE
Add custom Tiptap nodes with slash command menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tiptap/react": "^3.0.9",
         "@tiptap/starter-kit": "^3.0.9",
+        "@tiptap/suggestion": "^3.0.9",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -1773,6 +1774,20 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/suggestion": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@tiptap/suggestion/-/suggestion-3.0.9.tgz",
+      "integrity": "sha512-irthqfUybezo3IwR6AXvyyTOtkzwfvvst58VXZtTnR1nN6NEcrs3TQoY3bGKGbN83bdiquKh6aU2nLnZfAhoXg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.0.9",
+        "@tiptap/pm": "^3.0.9"
       }
     },
     "node_modules/@types/babel__core": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@tiptap/react": "^3.0.9",
     "@tiptap/starter-kit": "^3.0.9",
+    "@tiptap/suggestion": "^3.0.9",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,9 +1,27 @@
 import { useEditor, EditorContent } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
+import SlashCommand from './extensions/SlashCommand'
+import {
+  PageHeader,
+  PanelHeader,
+  Description,
+  Dialogue,
+  Sfx,
+  NoCopy,
+} from './extensions/customNodes'
 
 export default function App() {
   const editor = useEditor({
-    extensions: [StarterKit],
+    extensions: [
+      StarterKit,
+      PageHeader,
+      PanelHeader,
+      Description,
+      Dialogue,
+      Sfx,
+      NoCopy,
+      SlashCommand,
+    ],
     content: '',
   })
 

--- a/src/extensions/SlashCommand.js
+++ b/src/extensions/SlashCommand.js
@@ -1,0 +1,112 @@
+import { Extension } from '@tiptap/core'
+import Suggestion from '@tiptap/suggestion'
+
+const SlashCommand = Extension.create({
+  name: 'slash-command',
+  addOptions() {
+    return {
+      suggestion: {
+        char: '/',
+        startOfLine: true,
+        items: ({ query }) => {
+          return [
+            {
+              title: 'Page Header',
+              command: ({ editor, range }) => {
+                editor.chain().focus().deleteRange(range).setPageHeader().run()
+              },
+            },
+            {
+              title: 'Panel Header',
+              command: ({ editor, range }) => {
+                editor.chain().focus().deleteRange(range).setPanelHeader().run()
+              },
+            },
+            {
+              title: 'Description',
+              command: ({ editor, range }) => {
+                editor.chain().focus().deleteRange(range).setDescription().run()
+              },
+            },
+            {
+              title: 'Dialogue',
+              command: ({ editor, range }) => {
+                editor.chain().focus().deleteRange(range).setDialogue().run()
+              },
+            },
+            {
+              title: 'SFX',
+              command: ({ editor, range }) => {
+                editor.chain().focus().deleteRange(range).setSfx().run()
+              },
+            },
+            {
+              title: 'No Copy',
+              command: ({ editor, range }) => {
+                editor.chain().focus().deleteRange(range).setNoCopy().run()
+              },
+            },
+          ].filter(item =>
+            item.title.toLowerCase().startsWith(query.toLowerCase())
+          )
+        },
+        render: () => {
+          let element
+
+          const renderItems = props => {
+            element.innerHTML = ''
+
+            props.items.forEach((item, index) => {
+              const div = document.createElement('div')
+              div.className = 'slash-command-item'
+              if (index === props.selected) {
+                div.classList.add('is-selected')
+              }
+              div.textContent = item.title
+              div.addEventListener('mousedown', event => {
+                event.preventDefault()
+                item.command(props)
+              })
+              element.append(div)
+            })
+          }
+
+          return {
+            onStart: props => {
+              element = document.createElement('div')
+              element.className = 'slash-command-menu'
+              renderItems(props)
+
+              const { top, left } = props.clientRect()
+              element.style.top = `${top + window.scrollY}px`
+              element.style.left = `${left + window.scrollX}px`
+              document.body.appendChild(element)
+            },
+            onUpdate(props) {
+              renderItems(props)
+              const { top, left } = props.clientRect()
+              element.style.top = `${top + window.scrollY}px`
+              element.style.left = `${left + window.scrollX}px`
+            },
+            onKeyDown(props) {
+              if (props.event.key === 'Escape') {
+                element.remove()
+                return true
+              }
+              return false
+            },
+            onExit() {
+              element.remove()
+            },
+          }
+        },
+      },
+    }
+  },
+  addProseMirrorPlugins() {
+    return [Suggestion({ ...this.options.suggestion })]
+  },
+})
+
+export default SlashCommand
+

--- a/src/extensions/customNodes.js
+++ b/src/extensions/customNodes.js
@@ -1,0 +1,86 @@
+import { Node, mergeAttributes } from '@tiptap/core'
+
+export const PageHeader = Node.create({
+  name: 'pageHeader',
+  group: 'block',
+  content: 'inline*',
+  parseHTML() {
+    return [{ tag: 'h1' }]
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ['h1', mergeAttributes(HTMLAttributes), 0]
+  },
+  addCommands() {
+    return {
+      setPageHeader:
+        () =>
+        ({ commands }) =>
+          commands.insertContent({ type: this.name }),
+    }
+  },
+})
+
+export const PanelHeader = Node.create({
+  name: 'panelHeader',
+  group: 'block',
+  content: 'inline*',
+  parseHTML() {
+    return [{ tag: 'h2' }]
+  },
+  renderHTML({ HTMLAttributes }) {
+    return ['h2', mergeAttributes(HTMLAttributes), 0]
+  },
+  addCommands() {
+    return {
+      setPanelHeader:
+        () =>
+        ({ commands }) =>
+          commands.insertContent({ type: this.name }),
+    }
+  },
+})
+
+function paragraphNode({ name, className }) {
+  return Node.create({
+    name,
+    group: 'block',
+    content: 'inline*',
+    parseHTML() {
+      return [{ tag: `p.${className}` }]
+    },
+    renderHTML({ HTMLAttributes }) {
+      return ['p', mergeAttributes(HTMLAttributes, { class: className }), 0]
+    },
+    addCommands() {
+      return {
+        [
+          `set${name.charAt(0).toUpperCase()}${name.slice(1)}`
+        ]:
+          () =>
+          ({ commands }) =>
+            commands.insertContent({ type: name }),
+      }
+    },
+  })
+}
+
+export const Description = paragraphNode({
+  name: 'description',
+  className: 'description',
+})
+
+export const Dialogue = paragraphNode({
+  name: 'dialogue',
+  className: 'dialogue',
+})
+
+export const Sfx = paragraphNode({
+  name: 'sfx',
+  className: 'sfx',
+})
+
+export const NoCopy = paragraphNode({
+  name: 'noCopy',
+  className: 'no-copy',
+})
+

--- a/src/index.css
+++ b/src/index.css
@@ -3,3 +3,44 @@
   border: 1px solid #ccc;
   min-height: 200px;
 }
+
+.page-header {
+  font-size: 2rem;
+  font-weight: bold;
+}
+
+.panel-header {
+  font-size: 1.5rem;
+  font-weight: bold;
+}
+
+.description {
+  font-style: italic;
+}
+
+.sfx {
+  font-weight: bold;
+  text-transform: uppercase;
+}
+
+.no-copy {
+  opacity: 0.6;
+}
+
+.slash-command-menu {
+  position: absolute;
+  background: white;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 4px;
+  z-index: 100;
+}
+
+.slash-command-item {
+  padding: 4px 8px;
+  cursor: pointer;
+}
+
+.slash-command-item.is-selected {
+  background: #eee;
+}


### PR DESCRIPTION
## Summary
- add custom node extensions for page headers, panel headers, descriptions, dialogue, SFX, and no-copy blocks
- implement slash command menu for inserting those blocks
- style custom nodes and menu

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688d8fa3b448832190cc590a67bfcafc