### PR TITLE
feat: add bubble menu for text formatting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "panelist",
       "version": "0.0.0",
       "dependencies": {
+        "@tiptap/extension-underline": "^3.0.9",
         "@tiptap/react": "^3.0.9",
         "@tiptap/starter-kit": "^3.0.9",
         "react": "^19.1.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@tiptap/extension-underline": "^3.0.9",
     "@tiptap/react": "^3.0.9",
     "@tiptap/starter-kit": "^3.0.9",
     "react": "^19.1.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,43 @@
 import { useEditor, EditorContent } from '@tiptap/react'
+import { BubbleMenu } from '@tiptap/react/menus'
 import StarterKit from '@tiptap/starter-kit'
+import Underline from '@tiptap/extension-underline'
 
 export default function App() {
   const editor = useEditor({
-    extensions: [StarterKit],
+    extensions: [StarterKit, Underline],
     content: '',
   })
 
-  return <EditorContent editor={editor} />
+  return (
+    <>
+      {editor && (
+        <BubbleMenu
+          className="bubble-menu"
+          editor={editor}
+          tippyOptions={{ duration: 100 }}
+        >
+          <button
+            onClick={() => editor.chain().focus().toggleBold().run()}
+            className={editor.isActive('bold') ? 'is-active' : ''}
+          >
+            B
+          </button>
+          <button
+            onClick={() => editor.chain().focus().toggleItalic().run()}
+            className={editor.isActive('italic') ? 'is-active' : ''}
+          >
+            I
+          </button>
+          <button
+            onClick={() => editor.chain().focus().toggleUnderline().run()}
+            className={editor.isActive('underline') ? 'is-active' : ''}
+          >
+            U
+          </button>
+        </BubbleMenu>
+      )}
+      <EditorContent editor={editor} />
+    </>
+  )
 }

--- a/src/index.css
+++ b/src/index.css
@@ -3,3 +3,22 @@
   border: 1px solid #ccc;
   min-height: 200px;
 }
+
+.bubble-menu {
+  display: flex;
+  gap: 0.25rem;
+  padding: 0.25rem;
+  border-radius: 0.25rem;
+  background: #fff;
+  border: 1px solid #ccc;
+}
+
+.bubble-menu button {
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.bubble-menu button.is-active {
+  font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- add Tiptap BubbleMenu with bold, italic, and underline controls
- style bubble menu and include underline extension dependency

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688d8fdc909c83218f136ed44affa607