### PR TITLE
fix: provide editor to slash command plugin

### DIFF
--- a/src/extensions/SlashCommand.js
+++ b/src/extensions/SlashCommand.js
@@ -104,7 +104,7 @@ const SlashCommand = Extension.create({
     }
   },
   addProseMirrorPlugins() {
-    return [Suggestion({ ...this.options.suggestion })]
+    return [Suggestion({ editor: this.editor, ...this.options.suggestion })]
   },
 })
 


### PR DESCRIPTION
## Summary
- ensure SlashCommand plugin passes editor instance to Suggestion

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- Manual: run headless jsdom editor, type `/p` and confirm no TypeError

------
https://chatgpt.com/codex/tasks/task_e_688d94d24d5c8321810aa2c5c4b3f5d1