### PR TITLE
feat: add collapsible sidebar layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ import {
   Sfx,
   NoCopy,
 } from './extensions/customNodes'
+import Sidebar from './components/Sidebar'
 
 export default function App() {
   const editor = useEditor({
@@ -29,34 +30,37 @@ export default function App() {
   })
 
   return (
-    <>
-      {editor && (
-        <BubbleMenu
-          className="bubble-menu"
-          editor={editor}
-          tippyOptions={{ duration: 100 }}
-        >
-          <button
-            onClick={() => editor.chain().focus().toggleBold().run()}
-            className={editor.isActive('bold') ? 'is-active' : ''}
+    <div className="app-layout">
+      <Sidebar />
+      <div className="editor-container">
+        {editor && (
+          <BubbleMenu
+            className="bubble-menu"
+            editor={editor}
+            tippyOptions={{ duration: 100 }}
           >
-            B
-          </button>
-          <button
-            onClick={() => editor.chain().focus().toggleItalic().run()}
-            className={editor.isActive('italic') ? 'is-active' : ''}
-          >
-            I
-          </button>
-          <button
-            onClick={() => editor.chain().focus().toggleUnderline().run()}
-            className={editor.isActive('underline') ? 'is-active' : ''}
-          >
-            U
-          </button>
-        </BubbleMenu>
-      )}
-      <EditorContent editor={editor} />
-    </>
+            <button
+              onClick={() => editor.chain().focus().toggleBold().run()}
+              className={editor.isActive('bold') ? 'is-active' : ''}
+            >
+              B
+            </button>
+            <button
+              onClick={() => editor.chain().focus().toggleItalic().run()}
+              className={editor.isActive('italic') ? 'is-active' : ''}
+            >
+              I
+            </button>
+            <button
+              onClick={() => editor.chain().focus().toggleUnderline().run()}
+              className={editor.isActive('underline') ? 'is-active' : ''}
+            >
+              U
+            </button>
+          </BubbleMenu>
+        )}
+        <EditorContent editor={editor} />
+      </div>
+    </div>
   )
 }

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,0 +1,47 @@
+import { useState, useEffect } from 'react'
+
+export default function Sidebar({ onSelectScript, onSelectFolder, renderAssets }) {
+  const [collapsed, setCollapsed] = useState(false)
+  const [recentScripts, setRecentScripts] = useState([])
+  const [projectFolders, setProjectFolders] = useState([])
+
+  useEffect(() => {
+    const scripts = JSON.parse(localStorage.getItem('recentScripts') || '[]')
+    const folders = JSON.parse(localStorage.getItem('projectFolders') || '[]')
+    setRecentScripts(scripts)
+    setProjectFolders(folders)
+  }, [])
+
+  return (
+    <aside className={`sidebar${collapsed ? ' collapsed' : ''}`}>
+      <button
+        className="collapse-toggle"
+        onClick={() => setCollapsed((c) => !c)}
+      >
+        {collapsed ? '>' : '<'}
+      </button>
+      <div className="sidebar-content">
+        <section>
+          <h3>Recent Scripts</h3>
+          <ul>
+            {recentScripts.length === 0 && <li>No scripts</li>}
+            {recentScripts.map((s) => (
+              <li key={s} onClick={() => onSelectScript?.(s)}>{s}</li>
+            ))}
+          </ul>
+        </section>
+        <section>
+          <h3>Project Folders</h3>
+          <ul>
+            {projectFolders.length === 0 && <li>No folders</li>}
+            {projectFolders.map((f) => (
+              <li key={f} onClick={() => onSelectFolder?.(f)}>{f}</li>
+            ))}
+          </ul>
+        </section>
+        {renderAssets?.()}
+      </div>
+    </aside>
+  )
+}
+

--- a/src/style.css
+++ b/src/style.css
@@ -84,3 +84,55 @@ a {
   font-weight: bold;
   color: var(--text-color);
 }
+
+.app-layout {
+  display: flex;
+  height: 100vh;
+}
+
+.editor-container {
+  flex: 1;
+  overflow: auto;
+}
+
+.sidebar {
+  width: 250px;
+  background: #111;
+  border-right: 1px solid #333;
+  transition: width 0.3s ease;
+  overflow: hidden;
+  position: relative;
+}
+
+.sidebar.collapsed {
+  width: 40px;
+}
+
+.collapse-toggle {
+  position: absolute;
+  top: 10px;
+  right: -15px;
+  width: 30px;
+  height: 30px;
+  background: #111;
+  border: 1px solid #333;
+  border-radius: 50%;
+  color: var(--text-color);
+  cursor: pointer;
+}
+
+.sidebar-content {
+  padding: 1rem;
+}
+
+.sidebar-content ul {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1rem 0;
+}
+
+.sidebar-content li {
+  cursor: pointer;
+  padding: 0.25rem 0;
+}
+


### PR DESCRIPTION
## Summary
- add `Sidebar` component with collapsible state and placeholder sections
- apply flexbox layout to display sidebar next to editor
- style sidebar with slide animation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688d95d341488321bfb14e33749ba6af