### PR TITLE
feat: add SmartFlow keyboard navigation extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,14 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## Manual Testing
+
+The `SmartFlow` extension adds keyboard shortcuts for navigating script panels.
+
+1. Run `npm run dev` and open the editor.
+2. Create a `PageHeader` node. Press **Enter** to insert the next node (`PanelHeader`), then **Enter** again to continue through the flow (`Description` → `Dialogue`).
+3. Use **Tab** to move the cursor forward through nodes in the current panel.
+4. Use **Shift+Tab** to move the cursor backward within the panel.
+
+Verify that the cursor stops when reaching the start or end of a panel.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import { BubbleMenu } from '@tiptap/react/menus'
 import StarterKit from '@tiptap/starter-kit'
 import Underline from '@tiptap/extension-underline'
 import SlashCommand from './extensions/SlashCommand'
+import SmartFlow from './extensions/SmartFlow'
 import {
   PageHeader,
   PanelHeader,
@@ -22,6 +23,7 @@ export default function App() {
       Dialogue,
       Sfx,
       NoCopy,
+      SmartFlow,
       SlashCommand,
       Underline,
     ],

--- a/src/extensions/SmartFlow.js
+++ b/src/extensions/SmartFlow.js
@@ -1,0 +1,48 @@
+import { Extension } from '@tiptap/core'
+
+const flowMap = {
+  pageHeader: 'panelHeader',
+  panelHeader: 'description',
+  description: 'dialogue',
+  dialogue: 'dialogue',
+  sfx: 'dialogue',
+  noCopy: 'dialogue',
+}
+
+function isBoundary(name) {
+  return name === 'pageHeader' || name === 'panelHeader'
+}
+
+const SmartFlow = Extension.create({
+  name: 'smartFlow',
+  addKeyboardShortcuts() {
+    return {
+      Enter: () => {
+        const { $from } = this.editor.state.selection
+        const currentType = $from.parent.type.name
+        const nextType = flowMap[currentType]
+        if (!nextType) return false
+        this.editor.chain().focus().insertContent({ type: nextType }).run()
+        return true
+      },
+      Tab: () => {
+        const { $from } = this.editor.state.selection
+        const nextPos = $from.after()
+        const nextNode = this.editor.state.doc.nodeAt(nextPos)
+        if (!nextNode || isBoundary(nextNode.type.name)) return false
+        this.editor.commands.focus(nextPos)
+        return true
+      },
+      'Shift-Tab': () => {
+        const { $from } = this.editor.state.selection
+        const prevPos = $from.before()
+        const prevNode = this.editor.state.doc.nodeAt(prevPos)
+        if (!prevNode || isBoundary(prevNode.type.name) && prevNode.type.name !== 'panelHeader') return false
+        this.editor.commands.focus(prevPos)
+        return true
+      },
+    }
+  },
+})
+
+export default SmartFlow


### PR DESCRIPTION
## Summary
- add SmartFlow Tiptap extension for Enter/Tab navigation
- wire SmartFlow into editor setup
- document manual testing steps

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688d95d7133c83218a1a72c84e75e6ed