### PR TITLE
Display app name overlay

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -32,37 +32,40 @@ export default function App() {
   })
 
   return (
-    <div className="app-layout">
-      <Sidebar />
-      <div className="editor-container">
-        {editor && (
-          <BubbleMenu
-            className="bubble-menu"
-            editor={editor}
-            tippyOptions={{ duration: 100 }}
-          >
-            <button
-              onClick={() => editor.chain().focus().toggleBold().run()}
-              className={editor.isActive('bold') ? 'is-active' : ''}
+    <>
+      <div className="app-layout">
+        <Sidebar />
+        <div className="editor-container">
+          {editor && (
+            <BubbleMenu
+              className="bubble-menu"
+              editor={editor}
+              tippyOptions={{ duration: 100 }}
             >
-              B
-            </button>
-            <button
-              onClick={() => editor.chain().focus().toggleItalic().run()}
-              className={editor.isActive('italic') ? 'is-active' : ''}
-            >
-              I
-            </button>
-            <button
-              onClick={() => editor.chain().focus().toggleUnderline().run()}
-              className={editor.isActive('underline') ? 'is-active' : ''}
-            >
-              U
-            </button>
-          </BubbleMenu>
-        )}
-        <EditorContent editor={editor} />
+              <button
+                onClick={() => editor.chain().focus().toggleBold().run()}
+                className={editor.isActive('bold') ? 'is-active' : ''}
+              >
+                B
+              </button>
+              <button
+                onClick={() => editor.chain().focus().toggleItalic().run()}
+                className={editor.isActive('italic') ? 'is-active' : ''}
+              >
+                I
+              </button>
+              <button
+                onClick={() => editor.chain().focus().toggleUnderline().run()}
+                className={editor.isActive('underline') ? 'is-active' : ''}
+              >
+                U
+              </button>
+            </BubbleMenu>
+          )}
+          <EditorContent editor={editor} />
+        </div>
       </div>
-    </div>
+      <div className="app-name">Panelist</div>
+    </>
   )
 }

--- a/src/style.css
+++ b/src/style.css
@@ -136,3 +136,11 @@ a {
   padding: 0.25rem 0;
 }
 
+.app-name {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  font-size: clamp(1rem, 2vw, 1.5rem);
+  color: var(--text-color);
+}
+


### PR DESCRIPTION
## Summary
- Show app name in bottom-right corner of the app
- Style overlay with responsive sizing and fixed positioning

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688d98e62dec8321abb58f642de8948a