### PR TITLE
feat: improve editor layout and sidebar

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
 import { useEditor, EditorContent } from '@tiptap/react'
+import { useState } from 'react'
 import { BubbleMenu } from '@tiptap/react/menus'
 import StarterKit from '@tiptap/starter-kit'
 import Underline from '@tiptap/extension-underline'
@@ -15,6 +16,7 @@ import {
 import Sidebar from './components/Sidebar'
 
 export default function App() {
+  const [scriptTitle] = useState('Untitled Script')
   const editor = useEditor({
     extensions: [
       StarterKit,
@@ -35,6 +37,7 @@ export default function App() {
     <div className="app-layout">
       <Sidebar />
       <div className="editor-container">
+        <h1 className="editor-title">{scriptTitle}</h1>
         {editor && (
           <BubbleMenu
             className="bubble-menu"

--- a/src/style.css
+++ b/src/style.css
@@ -16,7 +16,7 @@ a {
 }
 
 .ProseMirror {
-  padding: 1rem;
+  padding: 2rem;
   border: 1px solid #333;
   min-height: 200px;
 }
@@ -93,6 +93,8 @@ a {
 .editor-container {
   flex: 1;
   overflow: auto;
+  padding: 2rem;
+  box-sizing: border-box;
 }
 
 .sidebar {
@@ -105,7 +107,18 @@ a {
 }
 
 .sidebar.collapsed {
-  width: 40px;
+  width: 0;
+  border-right: none;
+  overflow: visible;
+}
+
+.sidebar.collapsed .sidebar-content {
+  display: none;
+}
+
+.sidebar.collapsed .collapse-toggle {
+  left: 0;
+  right: auto;
 }
 
 .collapse-toggle {
@@ -134,5 +147,10 @@ a {
 .sidebar-content li {
   cursor: pointer;
   padding: 0.25rem 0;
+}
+
+.editor-title {
+  text-align: center;
+  margin: 0 0 1rem 0;
 }
 


### PR DESCRIPTION
## Summary
- add centered script title header above editor
- expand editor padding and hide sidebar completely when collapsed

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688d986807208321b9abcee43d392475