### PR TITLE
fix: close editor title css block

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -155,7 +155,8 @@ a {
 .editor-title {
   text-align: center;
   margin: 0 0 1rem 0;
-  
+}
+
 .app-name {
   position: fixed;
   bottom: 1rem;


### PR DESCRIPTION
## Summary
- close `.editor-title` css block and keep `.app-name` standalone

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e3bb741bc8321a95effea5463bf4f