### PR TITLE
feat: display app version

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -68,7 +68,7 @@ export default function App() {
           </>
         )}
       </div>
-      <div className="app-name">Panelist</div>
+      <div className="app-name">Panelist v{import.meta.env.__APP_VERSION__}</div>
     </div>
   )
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,10 @@
+/* eslint-env node */
+/* global process */
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  define: { __APP_VERSION__: JSON.stringify(process.env.npm_package_version) },
 })


### PR DESCRIPTION
## Summary
- inject package version into Vite build via __APP_VERSION__
- render Panelist version from import.meta.env.__APP_VERSION__

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e3bb1cd908321879ac0e29749bb37