### PR TITLE
feat: add script storage utilities

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -150,6 +150,23 @@ a {
 .sidebar-content li {
   cursor: pointer;
   padding: 0.25rem 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.sidebar-content li button {
+  margin-left: 0.5rem;
+}
+
+.new-script {
+  display: flex;
+  gap: 0.25rem;
+  margin-bottom: 0.5rem;
+}
+
+.new-script input {
+  flex: 1;
 }
 
 .editor-title {

--- a/src/utils/scriptStorage.js
+++ b/src/utils/scriptStorage.js
@@ -1,0 +1,58 @@
+import { mkdir, readFile, writeFile, unlink, readdir } from 'node:fs/promises'
+import { join } from 'node:path'
+import { cwd } from 'node:process'
+
+const scriptsDir = join(cwd(), 'scripts')
+
+async function ensureDir() {
+  await mkdir(scriptsDir, { recursive: true })
+}
+
+export async function listScripts() {
+  await ensureDir()
+  const files = await readdir(scriptsDir)
+  return files
+    .filter((f) => f.endsWith('.json'))
+    .map((f) => f.replace(/\.json$/, ''))
+}
+
+export async function createScript(name, data) {
+  await ensureDir()
+  const filePath = join(scriptsDir, `${name}.json`)
+  const payload = {
+    metadata: {
+      title: name,
+      createdAt: new Date().toISOString(),
+      ...data.metadata,
+    },
+    content: data.content ?? '',
+  }
+  await writeFile(filePath, JSON.stringify(payload, null, 2), 'utf8')
+  return payload
+}
+
+export async function readScript(name) {
+  const filePath = join(scriptsDir, `${name}.json`)
+  const content = await readFile(filePath, 'utf8')
+  return JSON.parse(content)
+}
+
+export async function updateScript(name, data) {
+  const existing = await readScript(name)
+  const updated = {
+    metadata: {
+      ...existing.metadata,
+      ...data.metadata,
+      updatedAt: new Date().toISOString(),
+    },
+    content: data.content ?? existing.content,
+  }
+  const filePath = join(scriptsDir, `${name}.json`)
+  await writeFile(filePath, JSON.stringify(updated, null, 2), 'utf8')
+  return updated
+}
+
+export async function deleteScript(name) {
+  const filePath = join(scriptsDir, `${name}.json`)
+  await unlink(filePath)
+}


### PR DESCRIPTION
## Summary
- add a `scripts/` directory to hold stored scripts
- implement CRUD helpers for managing JSON script files
- provide a sidebar UI to create, open, and delete stored scripts

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e3cc6ba288321a6226466c38ede22