### PR TITLE
Fix version display in App using __APP_VERSION__

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,3 +1,4 @@
+/* global __APP_VERSION__ */
 import { useEditor, EditorContent } from '@tiptap/react'
 import { useState } from 'react'
 import { BubbleMenu } from '@tiptap/react/menus'
@@ -68,7 +69,7 @@ export default function App() {
           </>
         )}
       </div>
-      <div className="app-name">Panelist v{import.meta.env.__APP_VERSION__}</div>
+      <div className="app-name">Panelist v{__APP_VERSION__}</div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- display app version using `__APP_VERSION__` constant defined in Vite config
- declare global for ESLint

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e3dac3bc88321991e26fcfa174fdd