### PR TITLE
Remove unsupported tippyOptions from BubbleMenu

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -44,7 +44,6 @@ export default function App() {
             <BubbleMenu
               className="bubble-menu"
               editor={editor}
-              tippyOptions={{ duration: 100 }}
             >
               <button
                 onClick={() => editor.chain().focus().toggleBold().run()}


### PR DESCRIPTION
## Summary
- Drop tippyOptions from BubbleMenu usage to match current Tiptap API

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e642e0a748321a32d33d185502a5a