### PR TITLE
Use StarterKit for underline support

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,7 +3,6 @@ import { useEditor, EditorContent } from '@tiptap/react'
 import { useState } from 'react'
 import { BubbleMenu } from '@tiptap/react/menus'
 import StarterKit from '@tiptap/starter-kit'
-import Underline from '@tiptap/extension-underline'
 import SlashCommand from './extensions/SlashCommand'
 import SmartFlow from './extensions/SmartFlow'
 import {
@@ -29,7 +28,6 @@ export default function App() {
       NoCopy,
       SmartFlow,
       SlashCommand,
-      Underline,
     ],
     content: '',
   })


### PR DESCRIPTION
## Summary
- remove direct Underline extension import and registration
- rely on StarterKit's built-in underline extension

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `node --input-type=module -e 'import { JSDOM } from "jsdom"; const dom = new JSDOM("<!doctype html><html><body></body></html>"); global.window = dom.window; global.document = window.document; global.navigator = { userAgent: "node.js" }; import StarterKit from "@tiptap/starter-kit"; import { Editor } from "@tiptap/core"; const editor = new Editor({ extensions: [StarterKit], content: "" }); console.log(editor.extensionManager.extensions.map(e => e.name));'`


------
https://chatgpt.com/codex/tasks/task_e_688e642ed2f88321963f9844b429e152