### PR TITLE
Use title field when listing scripts

### DIFF
--- a/src/utils/scriptRepository.js
+++ b/src/utils/scriptRepository.js
@@ -5,15 +5,16 @@ const TABLE = 'scripts'
 export async function listScripts() {
   const { data, error } = await supabase
     .from(TABLE)
-    .select('name')
-    .order('name')
+    .select('title')
+    .order('title')
   if (error) throw error
   return data
-    ? data.map((row) => row.name)
+    ? data.map((row) => row.title)
     : []
 }
 
 export async function createScript(name, data) {
+  const now = new Date().toISOString()
   const payload = {
     title: name,
     created_at: now,


### PR DESCRIPTION
## Summary
- query Supabase scripts table using `title` instead of `name`
- define timestamp constant when creating scripts

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e6b3390208321b47a21e538a1a428