### PR TITLE
feat: add projectId handling for scripts

### DIFF
--- a/src/utils/scriptRepository.js
+++ b/src/utils/scriptRepository.js
@@ -14,6 +14,7 @@ export async function listScripts() {
 }
 
 export async function createScript(name, data) {
+  const now = new Date().toISOString()
   const payload = {
     title: name,
     created_at: now,
@@ -35,13 +36,14 @@ export async function createScript(name, data) {
 export async function readScript(name) {
   const { data, error } = await supabase
     .from(TABLE)
-    .select('title, created_at, updated_at, content')
+    .select('title, project_id, created_at, updated_at, content')
     .eq('title', name)
     .single()
   if (error) throw error
   return {
     metadata: {
       title: data.title,
+      projectId: data.project_id,
       created_at: data.created_at,
       updated_at: data.updated_at,
     },
@@ -49,18 +51,20 @@ export async function readScript(name) {
   }
 }
 
-export async function updateScript(name, data) {
+export async function updateScript(name, data, projectId) {
   const existing = await readScript(name)
   const updated = {
     metadata: {
       ...existing.metadata,
       ...data.metadata,
+      projectId: projectId ?? existing.metadata.projectId,
       updated_at: new Date().toISOString(),
     },
     content: data.content ?? existing.content,
   }
   const row = {
     title: updated.metadata.title,
+    project_id: updated.metadata.projectId,
     created_at: updated.metadata.created_at,
     updated_at: updated.metadata.updated_at,
     content: updated.content,


### PR DESCRIPTION
## Summary
- include projectId in script reads
- allow updating a script's projectId

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e6b437d1c83218c0445e5cddd6772