### PR TITLE
feat: add Supabase project repository

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -5,12 +5,18 @@ import {
   readScript,
   deleteScript,
 } from '../utils/scriptRepository'
-
-export default function Sidebar({ onSelectScript, onSelectFolder, renderAssets }) {
+import {
+  listProjects,
+  createProject,
+  readProject,
+  deleteProject,
+} from '../utils/projectRepository'
+export default function Sidebar({ onSelectScript, onSelectProject, onSelectFolder, renderAssets }) {
   const [collapsed, setCollapsed] = useState(false)
   const [scripts, setScripts] = useState([])
-  const [newName, setNewName] = useState('')
-  const [projectFolders, setProjectFolders] = useState([])
+  const [newScriptName, setNewScriptName] = useState('')
+  const [projects, setProjects] = useState([])
+  const [newProjectName, setNewProjectName] = useState('')
 
   async function refreshScripts() {
     const result = await listScripts()
@@ -19,29 +25,55 @@ export default function Sidebar({ onSelectScript, onSelectFolder, renderAssets }
     setScripts(names)
   }
 
+  async function refreshProjects() {
+    const result = await listProjects()
+    const list = result?.data ?? result
+    const names = list.map((p) => p.name ?? p)
+    setProjects(names)
+  }
+
   useEffect(() => {
     refreshScripts()
-    const folders = JSON.parse(localStorage.getItem('projectFolders') || '[]')
-    setProjectFolders(folders)
+    refreshProjects()
   }, [])
 
-  async function handleCreate() {
-    const name = newName.trim()
+  async function handleCreateScript() {
+    const name = newScriptName.trim()
     if (!name) return
     await createScript(name, {})
-    setNewName('')
+    setNewScriptName('')
     refreshScripts()
   }
 
-  async function handleSelect(name) {
+  async function handleSelectScript(name) {
     const result = await readScript(name)
     const data = result?.data ?? result
     onSelectScript?.(name, data)
   }
 
-  async function handleDelete(name) {
+  async function handleDeleteScript(name) {
     await deleteScript(name)
     refreshScripts()
+  }
+
+  async function handleCreateProject() {
+    const name = newProjectName.trim()
+    if (!name) return
+    await createProject(name, {})
+    setNewProjectName('')
+    refreshProjects()
+  }
+
+  async function handleSelectProject(name) {
+    const result = await readProject(name)
+    const data = result?.data ?? result
+    const handler = onSelectProject ?? onSelectFolder
+    handler?.(name, data)
+  }
+
+  async function handleDeleteProject(name) {
+    await deleteProject(name)
+    refreshProjects()
   }
 
   return (
@@ -57,28 +89,39 @@ export default function Sidebar({ onSelectScript, onSelectFolder, renderAssets }
           <h3>Scripts</h3>
           <div className="new-script">
             <input
-              value={newName}
-              onChange={(e) => setNewName(e.target.value)}
+              value={newScriptName}
+              onChange={(e) => setNewScriptName(e.target.value)}
               placeholder="New script name"
             />
-            <button onClick={handleCreate}>Add</button>
+            <button onClick={handleCreateScript}>Add</button>
           </div>
           <ul>
             {scripts.length === 0 && <li>No scripts</li>}
             {scripts.map((s) => (
               <li key={s}>
-                <span onClick={() => handleSelect(s)}>{s}</span>
-                <button onClick={() => handleDelete(s)}>x</button>
+                <span onClick={() => handleSelectScript(s)}>{s}</span>
+                <button onClick={() => handleDeleteScript(s)}>x</button>
               </li>
             ))}
           </ul>
         </section>
         <section>
-          <h3>Project Folders</h3>
+          <h3>Projects</h3>
+          <div className="new-project">
+            <input
+              value={newProjectName}
+              onChange={(e) => setNewProjectName(e.target.value)}
+              placeholder="New project name"
+            />
+            <button onClick={handleCreateProject}>Add</button>
+          </div>
           <ul>
-            {projectFolders.length === 0 && <li>No folders</li>}
-            {projectFolders.map((f) => (
-              <li key={f} onClick={() => onSelectFolder?.(f)}>{f}</li>
+            {projects.length === 0 && <li>No projects</li>}
+            {projects.map((p) => (
+              <li key={p}>
+                <span onClick={() => handleSelectProject(p)}>{p}</span>
+                <button onClick={() => handleDeleteProject(p)}>x</button>
+              </li>
             ))}
           </ul>
         </section>

--- a/src/utils/projectRepository.js
+++ b/src/utils/projectRepository.js
@@ -1,0 +1,62 @@
+import { supabase } from './supabaseClient'
+
+const TABLE = 'projects'
+
+export async function listProjects() {
+  const { data, error } = await supabase
+    .from(TABLE)
+    .select('name')
+    .order('name')
+  if (error) throw error
+  return data ? data.map((row) => row.name) : []
+}
+
+export async function createProject(name, data = {}) {
+  const now = new Date().toISOString()
+  const payload = {
+    name,
+    created_at: now,
+    updated_at: now,
+    ...data,
+  }
+  const { data: inserted, error } = await supabase
+    .from(TABLE)
+    .insert(payload)
+    .select()
+    .single()
+  if (error) throw error
+  return inserted
+}
+
+export async function readProject(name) {
+  const { data, error } = await supabase
+    .from(TABLE)
+    .select('*')
+    .eq('name', name)
+    .single()
+  if (error) throw error
+  return data
+}
+
+export async function updateProject(name, data) {
+  const existing = await readProject(name)
+  const updated = {
+    ...existing,
+    ...data,
+    updated_at: new Date().toISOString(),
+  }
+  const { data: result, error } = await supabase
+    .from(TABLE)
+    .update(updated)
+    .eq('name', name)
+    .select()
+    .single()
+  if (error) throw error
+  return result
+}
+
+export async function deleteProject(name) {
+  const { error } = await supabase.from(TABLE).delete().eq('name', name)
+  if (error) throw error
+}
+

--- a/src/utils/scriptRepository.js
+++ b/src/utils/scriptRepository.js
@@ -14,6 +14,7 @@ export async function listScripts() {
 }
 
 export async function createScript(name, data) {
+  const now = new Date().toISOString()
   const payload = {
     title: name,
     created_at: now,


### PR DESCRIPTION
## Summary
- add project repository with Supabase CRUD helpers
- wire sidebar to manage projects via Supabase
- define script timestamp when creating scripts

## Testing
- `npm run lint`
- `npm run test:supabase` *(fails: Missing VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY environment variables.)*

------
https://chatgpt.com/codex/tasks/task_e_688e6b4bd2808321990064a7389f6f8c