### PR TITLE
Simplify script loading in Sidebar

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -12,15 +12,8 @@ export default function Sidebar({ onSelectScript, onSelectFolder, renderAssets }
   const [newName, setNewName] = useState('')
   const [projectFolders, setProjectFolders] = useState([])
 
-  async function refreshScripts() {
-    const result = await listScripts()
-    const list = result?.data ?? result
-    const names = list.map((s) => s.name ?? s)
-    setScripts(names)
-  }
-
   useEffect(() => {
-    refreshScripts()
+    ;(async () => setScripts(await listScripts()))()
     const folders = JSON.parse(localStorage.getItem('projectFolders') || '[]')
     setProjectFolders(folders)
   }, [])
@@ -30,18 +23,17 @@ export default function Sidebar({ onSelectScript, onSelectFolder, renderAssets }
     if (!name) return
     await createScript(name, {})
     setNewName('')
-    refreshScripts()
+    setScripts(await listScripts())
   }
 
   async function handleSelect(name) {
-    const result = await readScript(name)
-    const data = result?.data ?? result
+    const data = await readScript(name)
     onSelectScript?.(name, data)
   }
 
   async function handleDelete(name) {
     await deleteScript(name)
-    refreshScripts()
+    setScripts(await listScripts())
   }
 
   return (

--- a/src/utils/scriptRepository.js
+++ b/src/utils/scriptRepository.js
@@ -14,6 +14,7 @@ export async function listScripts() {
 }
 
 export async function createScript(name, data) {
+  const now = new Date().toISOString()
   const payload = {
     title: name,
     created_at: now,


### PR DESCRIPTION
## Summary
- Remove `refreshScripts` helper and call `setScripts(await listScripts())` directly for initial load and after create/delete operations.
- Read scripts directly with `await readScript(name)` when selecting a script.
- Define `now` timestamp in `createScript` to satisfy lint.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e6b4f4f748321bc585caff68129a4