### PR TITLE
Ensure Supabase client is authenticated before requests

### DIFF
--- a/src/utils/projectRepository.js
+++ b/src/utils/projectRepository.js
@@ -1,8 +1,9 @@
-import { supabase } from './supabaseClient'
+import { getSupabase } from './supabaseClient'
 
 const TABLE = 'projects'
 
 export async function listProjects() {
+  const supabase = await getSupabase()
   const { data, error } = await supabase
     .from(TABLE)
     .select('name')
@@ -19,6 +20,7 @@ export async function createProject(name, data = {}) {
     updated_at: now,
     ...data,
   }
+  const supabase = await getSupabase()
   const { data: inserted, error } = await supabase
     .from(TABLE)
     .insert(payload)
@@ -29,6 +31,7 @@ export async function createProject(name, data = {}) {
 }
 
 export async function readProject(name) {
+  const supabase = await getSupabase()
   const { data, error } = await supabase
     .from(TABLE)
     .select('*')
@@ -45,6 +48,7 @@ export async function updateProject(name, data) {
     ...data,
     updated_at: new Date().toISOString(),
   }
+  const supabase = await getSupabase()
   const { data: result, error } = await supabase
     .from(TABLE)
     .update(updated)
@@ -56,6 +60,7 @@ export async function updateProject(name, data) {
 }
 
 export async function deleteProject(name) {
+  const supabase = await getSupabase()
   const { error } = await supabase.from(TABLE).delete().eq('name', name)
   if (error) throw error
 }

--- a/src/utils/scriptRepository.js
+++ b/src/utils/scriptRepository.js
@@ -1,8 +1,9 @@
-import { supabase } from './supabaseClient'
+import { getSupabase } from './supabaseClient'
 
 const TABLE = 'scripts'
 
 export async function listScripts() {
+  const supabase = await getSupabase()
   const { data, error } = await supabase
     .from(TABLE)
     .select('title')
@@ -21,6 +22,7 @@ export async function createScript(name, data) {
     updated_at: now,
     content: data.content ?? '',
   }
+  const supabase = await getSupabase()
   const { error } = await supabase.from(TABLE).insert(payload)
   if (error) throw error
   return {
@@ -34,6 +36,7 @@ export async function createScript(name, data) {
 }
 
 export async function readScript(name) {
+  const supabase = await getSupabase()
   const { data, error } = await supabase
     .from(TABLE)
     .select('title, project_id, created_at, updated_at, content')
@@ -69,11 +72,13 @@ export async function updateScript(name, data, projectId) {
     updated_at: updated.metadata.updated_at,
     content: updated.content,
   }
+  const supabase = await getSupabase()
   const { error } = await supabase.from(TABLE).update(row).eq('title', name)
   if (error) throw error
 }
 
 export async function deleteScript(name) {
+  const supabase = await getSupabase()
   const { error } = await supabase.from(TABLE).delete().eq('title', name)
   if (error) throw error
 }

--- a/src/utils/supabaseClient.js
+++ b/src/utils/supabaseClient.js
@@ -4,3 +4,13 @@ const url = import.meta.env.VITE_SUPABASE_URL
 const key = import.meta.env.VITE_SUPABASE_ANON_KEY
 
 export const supabase = createClient(url, key)
+
+export async function getSupabase() {
+  const {
+    data: { session },
+    error,
+  } = await supabase.auth.getSession()
+  if (error) throw error
+  if (!session) throw new Error('User is not logged in')
+  return supabase
+}


### PR DESCRIPTION
## Summary
- verify Supabase session before using client
- guard project and script queries behind authentication

## Testing
- `npm run lint`
- `VITE_SUPABASE_URL='https://example.supabase.co' VITE_SUPABASE_ANON_KEY='testanonkey' npm run test:supabase`


------
https://chatgpt.com/codex/tasks/task_e_688e718e6eac8321bd55c99072cdd78f