### PR TITLE
Add authentication flow and handle unauthorized errors

### DIFF
--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -1,0 +1,41 @@
+import { useState } from 'react'
+import { signIn } from '../utils/auth.js'
+
+export default function Login({ onLogin }) {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+
+  async function handleSubmit(e) {
+    e.preventDefault()
+    setError('')
+    const { data, error: err } = await signIn(email, password)
+    if (err) {
+      setError(err.message)
+    } else {
+      onLogin?.(data.session)
+    }
+  }
+
+  return (
+    <div className="login">
+      <h1>Login</h1>
+      <form onSubmit={handleSubmit}>
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <button type="submit">Sign In</button>
+      </form>
+      {error && <p className="error">{error}</p>}
+    </div>
+  )
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,37 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { useEffect, useState } from 'react'
 import App from './App.jsx'
+import Login from './components/Login.jsx'
 import './style.css'
+import { supabase } from './utils/supabaseClient.js'
+
+function Root() {
+  const [session, setSession] = useState(null)
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data }) => {
+      setSession(data.session)
+    })
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      setSession(session)
+    })
+    return () => subscription.unsubscribe()
+  }, [])
+
+  if (!session) {
+    return <Login onLogin={setSession} />
+  }
+
+  return <App />
+}
+
+export default Root
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <Root />
   </StrictMode>,
 )

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -1,0 +1,9 @@
+import { supabase } from './supabaseClient.js'
+
+export function signIn(email, password) {
+  return supabase.auth.signInWithPassword({ email, password })
+}
+
+export function signOut() {
+  return supabase.auth.signOut()
+}

--- a/src/utils/projectRepository.js
+++ b/src/utils/projectRepository.js
@@ -2,66 +2,98 @@ import { getSupabase } from './supabaseClient'
 
 const TABLE = 'projects'
 
+function handleUnauthorized(error) {
+  if (error?.status === 401 || error?.message?.includes('not logged in')) {
+    window.location.reload()
+    return true
+  }
+  return false
+}
+
 export async function listProjects() {
-  const supabase = await getSupabase()
-  const { data, error } = await supabase
-    .from(TABLE)
-    .select('name')
-    .order('name')
-  if (error) throw error
-  return data ? data.map((row) => row.name) : []
+  try {
+    const supabase = await getSupabase()
+    const { data, error } = await supabase
+      .from(TABLE)
+      .select('name')
+      .order('name')
+    if (error) throw error
+    return data ? data.map((row) => row.name) : []
+  } catch (error) {
+    if (!handleUnauthorized(error)) throw error
+    return []
+  }
 }
 
 export async function createProject(name, data = {}) {
-  const now = new Date().toISOString()
-  const payload = {
-    name,
-    created_at: now,
-    updated_at: now,
-    ...data,
+  try {
+    const now = new Date().toISOString()
+    const payload = {
+      name,
+      created_at: now,
+      updated_at: now,
+      ...data,
+    }
+    const supabase = await getSupabase()
+    const { data: inserted, error } = await supabase
+      .from(TABLE)
+      .insert(payload)
+      .select()
+      .single()
+    if (error) throw error
+    return inserted
+  } catch (error) {
+    if (!handleUnauthorized(error)) throw error
+    return null
   }
-  const supabase = await getSupabase()
-  const { data: inserted, error } = await supabase
-    .from(TABLE)
-    .insert(payload)
-    .select()
-    .single()
-  if (error) throw error
-  return inserted
 }
 
 export async function readProject(name) {
-  const supabase = await getSupabase()
-  const { data, error } = await supabase
-    .from(TABLE)
-    .select('*')
-    .eq('name', name)
-    .single()
-  if (error) throw error
-  return data
+  try {
+    const supabase = await getSupabase()
+    const { data, error } = await supabase
+      .from(TABLE)
+      .select('*')
+      .eq('name', name)
+      .single()
+    if (error) throw error
+    return data
+  } catch (error) {
+    if (!handleUnauthorized(error)) throw error
+    return null
+  }
 }
 
 export async function updateProject(name, data) {
-  const existing = await readProject(name)
-  const updated = {
-    ...existing,
-    ...data,
-    updated_at: new Date().toISOString(),
+  try {
+    const existing = await readProject(name)
+    if (!existing) return null
+    const updated = {
+      ...existing,
+      ...data,
+      updated_at: new Date().toISOString(),
+    }
+    const supabase = await getSupabase()
+    const { data: result, error } = await supabase
+      .from(TABLE)
+      .update(updated)
+      .eq('name', name)
+      .select()
+      .single()
+    if (error) throw error
+    return result
+  } catch (error) {
+    if (!handleUnauthorized(error)) throw error
+    return null
   }
-  const supabase = await getSupabase()
-  const { data: result, error } = await supabase
-    .from(TABLE)
-    .update(updated)
-    .eq('name', name)
-    .select()
-    .single()
-  if (error) throw error
-  return result
 }
 
 export async function deleteProject(name) {
-  const supabase = await getSupabase()
-  const { error } = await supabase.from(TABLE).delete().eq('name', name)
-  if (error) throw error
+  try {
+    const supabase = await getSupabase()
+    const { error } = await supabase.from(TABLE).delete().eq('name', name)
+    if (error) throw error
+  } catch (error) {
+    if (!handleUnauthorized(error)) throw error
+  }
 }
-

--- a/src/utils/scriptRepository.js
+++ b/src/utils/scriptRepository.js
@@ -2,83 +2,113 @@ import { getSupabase } from './supabaseClient'
 
 const TABLE = 'scripts'
 
+function handleUnauthorized(error) {
+  if (error?.status === 401 || error?.message?.includes('not logged in')) {
+    window.location.reload()
+    return true
+  }
+  return false
+}
+
 export async function listScripts() {
-  const supabase = await getSupabase()
-  const { data, error } = await supabase
-    .from(TABLE)
-    .select('title')
-    .order('title')
-  if (error) throw error
-  return data
-    ? data.map((row) => row.title)
-    : []
+  try {
+    const supabase = await getSupabase()
+    const { data, error } = await supabase
+      .from(TABLE)
+      .select('title')
+      .order('title')
+    if (error) throw error
+    return data ? data.map((row) => row.title) : []
+  } catch (error) {
+    if (!handleUnauthorized(error)) throw error
+    return []
+  }
 }
 
 export async function createScript(name, data) {
-  const now = new Date().toISOString()
-  const payload = {
-    title: name,
-    created_at: now,
-    updated_at: now,
-    content: data.content ?? '',
-  }
-  const supabase = await getSupabase()
-  const { error } = await supabase.from(TABLE).insert(payload)
-  if (error) throw error
-  return {
-    metadata: {
-      title: payload.title,
-      created_at: payload.created_at,
-      updated_at: payload.updated_at,
-    },
-    content: payload.content,
+  try {
+    const now = new Date().toISOString()
+    const payload = {
+      title: name,
+      created_at: now,
+      updated_at: now,
+      content: data.content ?? '',
+    }
+    const supabase = await getSupabase()
+    const { error } = await supabase.from(TABLE).insert(payload)
+    if (error) throw error
+    return {
+      metadata: {
+        title: payload.title,
+        created_at: payload.created_at,
+        updated_at: payload.updated_at,
+      },
+      content: payload.content,
+    }
+  } catch (error) {
+    if (!handleUnauthorized(error)) throw error
+    return null
   }
 }
 
 export async function readScript(name) {
-  const supabase = await getSupabase()
-  const { data, error } = await supabase
-    .from(TABLE)
-    .select('title, project_id, created_at, updated_at, content')
-    .eq('title', name)
-    .single()
-  if (error) throw error
-  return {
-    metadata: {
-      title: data.title,
-      projectId: data.project_id,
-      created_at: data.created_at,
-      updated_at: data.updated_at,
-    },
-    content: data.content,
+  try {
+    const supabase = await getSupabase()
+    const { data, error } = await supabase
+      .from(TABLE)
+      .select('title, project_id, created_at, updated_at, content')
+      .eq('title', name)
+      .single()
+    if (error) throw error
+    return {
+      metadata: {
+        title: data.title,
+        projectId: data.project_id,
+        created_at: data.created_at,
+        updated_at: data.updated_at,
+      },
+      content: data.content,
+    }
+  } catch (error) {
+    if (!handleUnauthorized(error)) throw error
+    return null
   }
 }
 
 export async function updateScript(name, data, projectId) {
-  const existing = await readScript(name)
-  const updated = {
-    metadata: {
-      ...existing.metadata,
-      ...data.metadata,
-      projectId: projectId ?? existing.metadata.projectId,
-      updated_at: new Date().toISOString(),
-    },
-    content: data.content ?? existing.content,
+  try {
+    const existing = await readScript(name)
+    if (!existing) return null
+    const updated = {
+      metadata: {
+        ...existing.metadata,
+        ...data.metadata,
+        projectId: projectId ?? existing.metadata.projectId,
+        updated_at: new Date().toISOString(),
+      },
+      content: data.content ?? existing.content,
+    }
+    const row = {
+      title: updated.metadata.title,
+      project_id: updated.metadata.projectId,
+      created_at: updated.metadata.created_at,
+      updated_at: updated.metadata.updated_at,
+      content: updated.content,
+    }
+    const supabase = await getSupabase()
+    const { error } = await supabase.from(TABLE).update(row).eq('title', name)
+    if (error) throw error
+  } catch (error) {
+    if (!handleUnauthorized(error)) throw error
   }
-  const row = {
-    title: updated.metadata.title,
-    project_id: updated.metadata.projectId,
-    created_at: updated.metadata.created_at,
-    updated_at: updated.metadata.updated_at,
-    content: updated.content,
-  }
-  const supabase = await getSupabase()
-  const { error } = await supabase.from(TABLE).update(row).eq('title', name)
-  if (error) throw error
 }
 
 export async function deleteScript(name) {
-  const supabase = await getSupabase()
-  const { error } = await supabase.from(TABLE).delete().eq('title', name)
-  if (error) throw error
+  try {
+    const supabase = await getSupabase()
+    const { error } = await supabase.from(TABLE).delete().eq('title', name)
+    if (error) throw error
+  } catch (error) {
+    if (!handleUnauthorized(error)) throw error
+  }
 }


### PR DESCRIPTION
## Summary
- Add Supabase auth helpers and login form to manage sessions
- Check session on startup and render login screen when unauthenticated
- Redirect to login when repository calls encounter unauthorized errors

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e785e3c6c832187554ece6782acda