### PR TITLE
feat: add sign up option

### DIFF
--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -1,15 +1,22 @@
 import { useState } from 'react'
-import { signIn } from '../utils/auth.js'
+import { signIn, signUp } from '../utils/auth.js'
 
 export default function Login({ onLogin }) {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState('')
+  const [isSignUp, setIsSignUp] = useState(false)
 
   async function handleSubmit(e) {
     e.preventDefault()
     setError('')
-    const { data, error: err } = await signIn(email, password)
+    let result
+    if (isSignUp) {
+      result = await signUp(email, password)
+    } else {
+      result = await signIn(email, password)
+    }
+    const { data, error: err } = result
     if (err) {
       setError(err.message)
     } else {
@@ -19,7 +26,7 @@ export default function Login({ onLogin }) {
 
   return (
     <div className="login">
-      <h1>Login</h1>
+      <h1>{isSignUp ? 'Sign Up' : 'Login'}</h1>
       <form onSubmit={handleSubmit}>
         <input
           type="email"
@@ -33,8 +40,14 @@ export default function Login({ onLogin }) {
           value={password}
           onChange={(e) => setPassword(e.target.value)}
         />
-        <button type="submit">Sign In</button>
+        <button type="submit">{isSignUp ? 'Sign Up' : 'Sign In'}</button>
       </form>
+      <button
+        type="button"
+        onClick={() => setIsSignUp((s) => !s)}
+      >
+        {isSignUp ? 'Have an account? Sign In' : 'Need an account? Sign Up'}
+      </button>
       {error && <p className="error">{error}</p>}
     </div>
   )

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -1,5 +1,9 @@
 import { supabase } from './supabaseClient.js'
 
+export function signUp(email, password) {
+  return supabase.auth.signUp({ email, password })
+}
+
 export function signIn(email, password) {
   return supabase.auth.signInWithPassword({ email, password })
 }


### PR DESCRIPTION
## Summary
- add Supabase sign-up utility
- toggle between sign in and sign up for new sessions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e7aba513083219a65c94a6d052e7b