### PR TITLE
chore: validate login fields before sign up

### DIFF
--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -10,6 +10,10 @@ export default function Login({ onLogin }) {
   async function handleSubmit(e) {
     e.preventDefault()
     setError('')
+    if (!email || !password) {
+      setError('Email and password are required')
+      return
+    }
     let result
     if (isSignUp) {
       result = await signUp(email, password)


### PR DESCRIPTION
## Summary
- require email and password before calling auth helpers

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run test:supabase` *(fails: Missing VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_688e7ddad3f48321bff92e54ab645700