### PR TITLE
Validate login credentials before authentication

### DIFF
--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -10,12 +10,28 @@ export default function Login({ onLogin }) {
   async function handleSubmit(e) {
     e.preventDefault()
     setError('')
+
+    const trimmedEmail = email.trim()
+    const trimmedPassword = password.trim()
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+    if (!trimmedEmail || !emailRegex.test(trimmedEmail)) {
+      setError('Please enter a valid email address.')
+      return
+    }
+
+    if (!trimmedPassword || trimmedPassword.length < 8) {
+      setError('Password must be at least 8 characters long.')
+      return
+    }
+
     let result
     if (isSignUp) {
-      result = await signUp(email, password)
+      result = await signUp(trimmedEmail, trimmedPassword)
     } else {
-      result = await signIn(email, password)
+      result = await signIn(trimmedEmail, trimmedPassword)
     }
+
     const { data, error: err } = result
     if (err) {
       setError(err.message)


### PR DESCRIPTION
## Summary
- validate email and password before signing in or up

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e7dd57ac8832197cf0cc6e493adb7