### PR TITLE
chore: add error logging for auth

### DIFF
--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -30,14 +30,21 @@ export default function Login({ onLogin }) {
     }
 
     let result
-    if (isSignUp) {
-      result = await signUp(trimmedEmail, trimmedPassword)
-    } else {
-      result = await signIn(trimmedEmail, trimmedPassword)
+    try {
+      if (isSignUp) {
+        result = await signUp(trimmedEmail, trimmedPassword)
+      } else {
+        result = await signIn(trimmedEmail, trimmedPassword)
+      }
+    } catch (err) {
+      console.error('Unexpected auth error:', err)
+      setError(err.message)
+      return
     }
 
     const { data, error: err } = result
     if (err) {
+      console.error('Auth error:', err)
       setError(err.message)
     } else {
       onLogin?.(data.session)

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -1,13 +1,40 @@
 import { supabase } from './supabaseClient.js'
 
-export function signUp(email, password) {
-  return supabase.auth.signUp({ email, password })
+export async function signUp(email, password) {
+  try {
+    const result = await supabase.auth.signUp({ email, password })
+    if (result.error) {
+      console.error('signUp error:', result.error)
+    }
+    return result
+  } catch (error) {
+    console.error('unexpected signUp error:', error)
+    return { data: null, error }
+  }
 }
 
-export function signIn(email, password) {
-  return supabase.auth.signInWithPassword({ email, password })
+export async function signIn(email, password) {
+  try {
+    const result = await supabase.auth.signInWithPassword({ email, password })
+    if (result.error) {
+      console.error('signIn error:', result.error)
+    }
+    return result
+  } catch (error) {
+    console.error('unexpected signIn error:', error)
+    return { data: null, error }
+  }
 }
 
-export function signOut() {
-  return supabase.auth.signOut()
+export async function signOut() {
+  try {
+    const result = await supabase.auth.signOut()
+    if (result.error) {
+      console.error('signOut error:', result.error)
+    }
+    return result
+  } catch (error) {
+    console.error('unexpected signOut error:', error)
+    return { error }
+  }
 }


### PR DESCRIPTION
## Summary
- add detailed console logging to signIn, signUp, and signOut helpers
- catch and report auth errors during login/signup submissions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688ea3f7da3c83218c77736892fe72b8