### PR TITLE
Include user id in project creation

### DIFF
--- a/src/utils/projectRepository.js
+++ b/src/utils/projectRepository.js
@@ -28,13 +28,19 @@ export async function listProjects() {
 export async function createProject(name, data = {}) {
   try {
     const now = new Date().toISOString()
+    const supabase = await getSupabase()
+    const {
+      data: { user },
+      error: userError,
+    } = await supabase.auth.getUser()
+    if (userError) throw userError
     const payload = {
       name,
       created_at: now,
       updated_at: now,
+      user_id: user.id,
       ...data,
     }
-    const supabase = await getSupabase()
     const { data: inserted, error } = await supabase
       .from(TABLE)
       .insert(payload)


### PR DESCRIPTION
## Summary
- ensure `createProject` associates new projects with the current user's id for row-level security compliance

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run test:supabase` *(fails: Missing VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY environment variables.)*

------
https://chatgpt.com/codex/tasks/task_e_688ea821fcb08321ab49d1dca5cdc315