### PR TITLE
Add sign-out button to sidebar

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,7 +15,7 @@ import {
 } from './extensions/customNodes'
 import Sidebar from './components/Sidebar'
 
-export default function App() {
+export default function App({ onSignOut }) {
   const [scriptTitle] = useState('Untitled Script')
   const editor = useEditor({
     extensions: [
@@ -34,7 +34,7 @@ export default function App() {
 
   return (
     <div className="app-layout">
-      <Sidebar />
+      <Sidebar onSignOut={onSignOut} />
       <div className="editor-container">
         <h1 className="editor-title">{scriptTitle}</h1>
         {editor && (

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -11,7 +11,9 @@ import {
   readProject,
   deleteProject,
 } from '../utils/projectRepository'
-export default function Sidebar({ onSelectScript, onSelectProject, onSelectFolder, renderAssets }) {
+import { signOut } from '../utils/auth.js'
+
+export default function Sidebar({ onSelectScript, onSelectProject, onSelectFolder, renderAssets, onSignOut }) {
   const [collapsed, setCollapsed] = useState(false)
   const [scripts, setScripts] = useState([])
   const [newScriptName, setNewScriptName] = useState('')
@@ -76,6 +78,11 @@ export default function Sidebar({ onSelectScript, onSelectProject, onSelectFolde
     refreshProjects()
   }
 
+  async function handleSignOut() {
+    await signOut()
+    onSignOut?.()
+  }
+
   return (
     <aside className={`sidebar${collapsed ? ' collapsed' : ''}`}>
       <button
@@ -126,6 +133,7 @@ export default function Sidebar({ onSelectScript, onSelectProject, onSelectFolde
           </ul>
         </section>
         {renderAssets?.()}
+        <button onClick={handleSignOut}>Sign out</button>
       </div>
     </aside>
   )

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -25,7 +25,7 @@ function Root() {
     return <Login onLogin={setSession} />
   }
 
-  return <App />
+  return <App onSignOut={() => setSession(null)} />
 }
 
 export default Root


### PR DESCRIPTION
## Summary
- add a "Sign out" button to the sidebar and hook it up to Supabase auth
- propagate a sign-out callback through `App` so the root clears the session

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688ea92a17c48321a72097690513c97d