### PR TITLE
Add autocomplete attributes to login inputs

### DIFF
--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -57,12 +57,14 @@ export default function Login({ onLogin }) {
       <form onSubmit={handleSubmit}>
         <input
           type="email"
+          autoComplete="email"
           placeholder="Email"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
         />
         <input
           type="password"
+          autoComplete="current-password"
           placeholder="Password"
           value={password}
           onChange={(e) => setPassword(e.target.value)}


### PR DESCRIPTION
## Summary
- add `autoComplete="email"` to login email input
- add `autoComplete="current-password"` to login password input

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688ead3484508321aac1f566e1b42a02