### PR TITLE
feat: add project header and script creation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
 /* global __APP_VERSION__ */
 import { useEditor, EditorContent } from '@tiptap/react'
-import { useState } from 'react'
+import { useState, useRef } from 'react'
 import { BubbleMenu } from '@tiptap/react/menus'
 import StarterKit from '@tiptap/starter-kit'
 import SlashCommand from './extensions/SlashCommand'
@@ -14,9 +14,27 @@ import {
   NoCopy,
 } from './extensions/customNodes'
 import Sidebar from './components/Sidebar'
+import { createScript } from './utils/scriptRepository'
+
+function ProjectHeader({ projectName, onAddScript, disabled }) {
+  return (
+    <div className="project-header">
+      <span>{projectName ?? 'No project selected'}</span>
+      <button
+        className="add-script-btn"
+        onClick={onAddScript}
+        disabled={disabled}
+      >
+        +
+      </button>
+    </div>
+  )
+}
 
 export default function App({ onSignOut }) {
-  const [scriptTitle] = useState('Untitled Script')
+  const [scriptTitle, setScriptTitle] = useState('Untitled Script')
+  const [activeProject, setActiveProject] = useState(null)
+  const sidebarRef = useRef(null)
   const editor = useEditor({
     extensions: [
       StarterKit,
@@ -32,10 +50,38 @@ export default function App({ onSignOut }) {
     content: '',
   })
 
+  async function handleAddScript() {
+    if (!activeProject) return
+    const name = prompt('New script name:')?.trim()
+    if (!name) return
+    await createScript(name, {}, activeProject.id)
+    await sidebarRef.current?.refreshScripts(activeProject.id)
+    await sidebarRef.current?.selectScript(name)
+  }
+
+  function handleSelectProject(name, data) {
+    setActiveProject(data)
+  }
+
+  function handleSelectScript(name, data) {
+    setScriptTitle(name)
+    editor?.commands?.setContent(data.content ?? '')
+  }
+
   return (
     <div className="app-layout">
-      <Sidebar onSignOut={onSignOut} />
+      <Sidebar
+        ref={sidebarRef}
+        onSelectProject={handleSelectProject}
+        onSelectScript={handleSelectScript}
+        onSignOut={onSignOut}
+      />
       <div className="editor-container">
+        <ProjectHeader
+          projectName={activeProject?.name}
+          onAddScript={handleAddScript}
+          disabled={!activeProject}
+        />
         <h1 className="editor-title">{scriptTitle}</h1>
         {editor && (
           <>

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, forwardRef, useImperativeHandle } from 'react'
 import {
   listScripts,
   createScript,
@@ -13,13 +13,16 @@ import {
 } from '../utils/projectRepository'
 import { signOut } from '../utils/auth.js'
 
-export default function Sidebar({
-  onSelectScript,
-  onSelectProject,
-  onSelectFolder,
-  renderAssets,
-  onSignOut,
-}) {
+function Sidebar(
+  {
+    onSelectScript,
+    onSelectProject,
+    onSelectFolder,
+    renderAssets,
+    onSignOut,
+  },
+  ref,
+) {
   const [collapsed, setCollapsed] = useState(false)
   const [scripts, setScripts] = useState([])
   const [newScriptName, setNewScriptName] = useState('')
@@ -122,6 +125,11 @@ export default function Sidebar({
     onSignOut?.()
   }
 
+  useImperativeHandle(ref, () => ({
+    refreshScripts,
+    selectScript: handleSelectScript,
+  }))
+
   return (
     <aside className={`sidebar${collapsed ? ' collapsed' : ''}`}>
       <button
@@ -194,4 +202,6 @@ export default function Sidebar({
     </aside>
   )
 }
+
+export default forwardRef(Sidebar)
 

--- a/src/style.css
+++ b/src/style.css
@@ -100,6 +100,21 @@ a {
   box-sizing: border-box;
 }
 
+.project-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.project-header .add-script-btn {
+  border: none;
+  background: none;
+  color: var(--accent-color);
+  cursor: pointer;
+  font-size: 1.5rem;
+}
+
 .sidebar {
   width: 250px;
   background: #111;


### PR DESCRIPTION
## Summary
- add project header showing active project with quick-add script button
- refresh script list and select new scripts after creation via Sidebar ref
- style header and expose Sidebar methods via forwardRef

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run test:supabase` *(fails: Missing VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY environment variables.)*


------
https://chatgpt.com/codex/tasks/task_e_688ec261b72483219908e1c4ab3bb292