### PR TITLE
Highlight active script in sidebar

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -19,6 +19,7 @@ export default function Sidebar({
   onSelectFolder,
   renderAssets,
   onSignOut,
+  activeScript: activeScriptProp,
 }) {
   const [collapsed, setCollapsed] = useState(false)
   const [scripts, setScripts] = useState([])
@@ -28,6 +29,16 @@ export default function Sidebar({
   const [newProjectName, setNewProjectName] = useState('')
   const [projectError, setProjectError] = useState('')
   const [selectedProject, setSelectedProject] = useState(null)
+  const [activeScriptState, setActiveScriptState] = useState(
+    activeScriptProp ?? null,
+  )
+  const activeScript = activeScriptProp ?? activeScriptState
+
+  useEffect(() => {
+    if (activeScriptProp !== undefined) {
+      setActiveScriptState(activeScriptProp)
+    }
+  }, [activeScriptProp])
 
   async function refreshScripts(projectId) {
     if (!projectId) {
@@ -72,6 +83,7 @@ export default function Sidebar({
   async function handleSelectScript(name) {
     const result = await readScript(name)
     const data = result?.data ?? result
+    setActiveScriptState(name)
     onSelectScript?.(name, data)
   }
 
@@ -99,6 +111,7 @@ export default function Sidebar({
     const result = await readProject(name)
     const data = result?.data ?? result
     setSelectedProject(data)
+    setActiveScriptState(null)
     const handler = onSelectProject ?? onSelectFolder
     handler?.(name, data)
     refreshScripts(data?.id)
@@ -179,7 +192,10 @@ export default function Sidebar({
               <ul>
                 {scripts.length === 0 && <li>No scripts</li>}
                 {scripts.map((s) => (
-                  <li key={s}>
+                  <li
+                    key={s}
+                    className={s === activeScript ? 'active-script' : ''}
+                  >
                     <span onClick={() => handleSelectScript(s)}>{s}</span>
                     <button onClick={() => handleDeleteScript(s)}>x</button>
                   </li>

--- a/src/style.css
+++ b/src/style.css
@@ -159,6 +159,11 @@ a {
   margin-left: 0.5rem;
 }
 
+.sidebar-content li.active-script {
+  font-weight: bold;
+  color: var(--accent-color);
+}
+
 .new-script {
   display: flex;
   gap: 0.25rem;


### PR DESCRIPTION
## Summary
- track active script within Sidebar component and allow optional prop override
- reset active script when changing projects and highlight active entry
- style active script list item for visual emphasis

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run test:supabase` *(fails: Missing VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_688ec26c33908321be27de48ccda3b2d