### PR TITLE
fix: pass ref to Sidebar component

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -20,7 +20,7 @@ function Sidebar({
   renderAssets,
   onSignOut,
   activeScript: activeScriptProp,
-}) {
+}, ref) {
   const [collapsed, setCollapsed] = useState(false)
   const [scripts, setScripts] = useState([])
   const [newScriptName, setNewScriptName] = useState('')


### PR DESCRIPTION
## Summary
- pass ref to Sidebar to support `forwardRef` and `useImperativeHandle`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: `currentScript` is not defined in `src/App.jsx`)*

------
https://chatgpt.com/codex/tasks/task_e_688ec5c0650c8321927d23702cc481aa