### PR TITLE
Scope scripts to projects

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -35,6 +35,7 @@ export default function App({ onSignOut }) {
   const [scriptTitle, setScriptTitle] = useState('Untitled Script')
   const [activeProject, setActiveProject] = useState(null)
   const sidebarRef = useRef(null)
+  const currentScript = { content: '' }
   const editor = useEditor({
     extensions: [
       StarterKit,

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -20,7 +20,7 @@ function Sidebar({
   renderAssets,
   onSignOut,
   activeScript: activeScriptProp,
-}) {
+}, ref) {
   const [collapsed, setCollapsed] = useState(false)
   const [scripts, setScripts] = useState([])
   const [newScriptName, setNewScriptName] = useState('')
@@ -40,14 +40,14 @@ function Sidebar({
     }
   }, [activeScriptProp])
 
-  async function refreshScripts(projectId) {
-    if (!projectId) {
-      setScripts([])
-      return
+    async function refreshScripts(projectId) {
+      if (!projectId) {
+        setScripts([])
+        return
+      }
+      const names = await listScripts(projectId)
+      setScripts(names)
     }
-    const names = await listScripts(projectId)
-    setScripts(names)
-  }
 
   async function refreshProjects() {
     const result = await listProjects()
@@ -80,17 +80,17 @@ function Sidebar({
     }
   }
 
-  async function handleSelectScript(name) {
-    const result = await readScript(name)
-    const data = result?.data ?? result
-    setActiveScriptState(name)
-    onSelectScript?.(name, data)
-  }
+    async function handleSelectScript(name) {
+      const result = await readScript(name, selectedProject?.id)
+      const data = result?.data ?? result
+      setActiveScriptState(name)
+      onSelectScript?.(name, data)
+    }
 
-  async function handleDeleteScript(name) {
-    await deleteScript(name)
-    refreshScripts(selectedProject?.id)
-  }
+    async function handleDeleteScript(name) {
+      await deleteScript(name, selectedProject?.id)
+      refreshScripts(selectedProject?.id)
+    }
 
   async function handleCreateProject() {
     const name = newProjectName.trim()


### PR DESCRIPTION
## Summary
- filter scripts by project ID and persist project ID on create
- ensure read/update/delete operations scope by project
- update sidebar to send project IDs with script actions

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688ec5cb644c8321b254e5a2189a4b44