### PR TITLE
Rename scripts table to pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ npm run test:supabase
 ```
 
 The script will report whether the project can reach the configured Supabase instance.
-Scripts are persisted in a Supabase table called `scripts`.
+Scripts are persisted in a Supabase table called `pages`.
 
 To create the table, run the following SQL in the Supabase SQL editor:
 
 ```sql
-create table if not exists scripts (
+create table if not exists pages (
   id uuid primary key default gen_random_uuid(),
   title text,
   content jsonb,
@@ -48,6 +48,6 @@ create table if not exists scripts (
 Seed it with a sample row if desired:
 
 ```sql
-insert into scripts (title, content, created_at, updated_at)
+insert into pages (title, content, created_at, updated_at)
 values ('Example', '{}'::jsonb, now(), now());
 ```

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,15 +14,15 @@ import {
   NoCopy,
 } from './extensions/customNodes'
 import Sidebar from './components/Sidebar'
-import { createScript } from './utils/scriptRepository'
+import { createPage } from './utils/pageRepository'
 
-function ProjectHeader({ projectName, onAddScript, disabled }) {
+function ProjectHeader({ projectName, onAddPage, disabled }) {
   return (
     <div className="project-header">
       <span>{projectName ?? 'No project selected'}</span>
       <button
-        className="add-script-btn"
-        onClick={onAddScript}
+        className="add-page-btn"
+        onClick={onAddPage}
         disabled={disabled}
       >
         +
@@ -32,10 +32,10 @@ function ProjectHeader({ projectName, onAddScript, disabled }) {
 }
 
 export default function App({ onSignOut }) {
-  const [scriptTitle, setScriptTitle] = useState('Untitled Script')
+  const [pageTitle, setPageTitle] = useState('Untitled Page')
   const [activeProject, setActiveProject] = useState(null)
   const sidebarRef = useRef(null)
-  const currentScript = { content: '' }
+  const currentPage = { content: '' }
   const editor = useEditor({
     extensions: [
       StarterKit,
@@ -48,24 +48,24 @@ export default function App({ onSignOut }) {
       SmartFlow,
       SlashCommand,
     ],
-    content: currentScript.content,
+    content: currentPage.content,
   })
 
-  async function handleAddScript() {
+  async function handleAddPage() {
     if (!activeProject) return
-    const name = prompt('New script name:')?.trim()
+    const name = prompt('New page name:')?.trim()
     if (!name) return
-    await createScript(name, {}, activeProject.id)
-    await sidebarRef.current?.refreshScripts(activeProject.id)
-    await sidebarRef.current?.selectScript(name)
+    await createPage(name, {}, activeProject.id)
+    await sidebarRef.current?.refreshPages(activeProject.id)
+    await sidebarRef.current?.selectPage(name)
   }
 
   function handleSelectProject(name, data) {
     setActiveProject(data)
   }
 
-  function handleSelectScript(name, data) {
-    setScriptTitle(name)
+  function handleSelectPage(name, data) {
+    setPageTitle(name)
     editor?.commands?.setContent(data.content ?? '')
   }
 
@@ -74,16 +74,16 @@ export default function App({ onSignOut }) {
       <Sidebar
         ref={sidebarRef}
         onSelectProject={handleSelectProject}
-        onSelectScript={handleSelectScript}
+        onSelectPage={handleSelectPage}
         onSignOut={onSignOut}
       />
       <div className="editor-container">
         <ProjectHeader
           projectName={activeProject?.name}
-          onAddScript={handleAddScript}
+          onAddPage={handleAddPage}
           disabled={!activeProject}
         />
-        <h1 className="editor-title">{scriptTitle}</h1>
+        <h1 className="editor-title">{pageTitle}</h1>
         {editor && (
           <>
             <BubbleMenu

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,10 +1,10 @@
 import { useState, useEffect, forwardRef, useImperativeHandle } from 'react'
 import {
-  listScripts,
-  createScript,
-  readScript,
-  deleteScript,
-} from '../utils/scriptRepository'
+  listPages,
+  createPage,
+  readPage,
+  deletePage,
+} from '../utils/pageRepository'
 import {
   listProjects,
   createProject,
@@ -14,39 +14,39 @@ import {
 import { signOut } from '../utils/auth.js'
 
 function Sidebar({
-  onSelectScript,
+  onSelectPage,
   onSelectProject,
   onSelectFolder,
   renderAssets,
   onSignOut,
-  activeScript: activeScriptProp,
+  activePage: activePageProp,
 }, ref) {
   const [collapsed, setCollapsed] = useState(false)
-  const [scripts, setScripts] = useState([])
-  const [newScriptName, setNewScriptName] = useState('')
-  const [scriptError, setScriptError] = useState('')
+  const [pages, setPages] = useState([])
+  const [newPageName, setNewPageName] = useState('')
+  const [pageError, setPageError] = useState('')
   const [projects, setProjects] = useState([])
   const [newProjectName, setNewProjectName] = useState('')
   const [projectError, setProjectError] = useState('')
   const [selectedProject, setSelectedProject] = useState(null)
-  const [activeScriptState, setActiveScriptState] = useState(
-    activeScriptProp ?? null,
+  const [activePageState, setActivePageState] = useState(
+    activePageProp ?? null,
   )
-  const activeScript = activeScriptProp ?? activeScriptState
+  const activePage = activePageProp ?? activePageState
 
   useEffect(() => {
-    if (activeScriptProp !== undefined) {
-      setActiveScriptState(activeScriptProp)
+    if (activePageProp !== undefined) {
+      setActivePageState(activePageProp)
     }
-  }, [activeScriptProp])
+  }, [activePageProp])
 
-    async function refreshScripts(projectId) {
+    async function refreshPages(projectId) {
       if (!projectId) {
-        setScripts([])
+        setPages([])
         return
       }
-      const names = await listScripts(projectId)
-      setScripts(names)
+      const names = await listPages(projectId)
+      setPages(names)
     }
 
   async function refreshProjects() {
@@ -66,30 +66,30 @@ function Sidebar({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  async function handleCreateScript() {
-    const name = newScriptName.trim()
+  async function handleCreatePage() {
+    const name = newPageName.trim()
     if (!name || !selectedProject) return
     try {
-      await createScript(name, {}, selectedProject.id)
-      setNewScriptName('')
-      setScriptError('')
-      refreshScripts(selectedProject.id)
+      await createPage(name, {}, selectedProject.id)
+      setNewPageName('')
+      setPageError('')
+      refreshPages(selectedProject.id)
     } catch (err) {
-      console.error('Error creating script:', err)
-      setScriptError(err.message)
+      console.error('Error creating page:', err)
+      setPageError(err.message)
     }
   }
 
-    async function handleSelectScript(name) {
-      const result = await readScript(name, selectedProject?.id)
+    async function handleSelectPage(name) {
+      const result = await readPage(name, selectedProject?.id)
       const data = result?.data ?? result
-      setActiveScriptState(name)
-      onSelectScript?.(name, data)
+      setActivePageState(name)
+      onSelectPage?.(name, data)
     }
 
-    async function handleDeleteScript(name) {
-      await deleteScript(name, selectedProject?.id)
-      refreshScripts(selectedProject?.id)
+    async function handleDeletePage(name) {
+      await deletePage(name, selectedProject?.id)
+      refreshPages(selectedProject?.id)
     }
 
   async function handleCreateProject() {
@@ -111,10 +111,10 @@ function Sidebar({
     const result = await readProject(name)
     const data = result?.data ?? result
     setSelectedProject(data)
-    setActiveScriptState(null)
+    setActivePageState(null)
     const handler = onSelectProject ?? onSelectFolder
     handler?.(name, data)
-    refreshScripts(data?.id)
+    refreshPages(data?.id)
   }
 
   async function handleDeleteProject(name) {
@@ -125,7 +125,7 @@ function Sidebar({
         handleSelectProject(names[0])
       } else {
         setSelectedProject(null)
-        setScripts([])
+        setPages([])
       }
     }
   }
@@ -136,8 +136,8 @@ function Sidebar({
   }
 
   useImperativeHandle(ref, () => ({
-    refreshScripts,
-    selectScript: handleSelectScript,
+    refreshPages,
+    selectPage: handleSelectPage,
   }))
 
   return (
@@ -185,24 +185,24 @@ function Sidebar({
           {selectedProject && <h3>{selectedProject.name}</h3>}
           {selectedProject && (
             <>
-              <div className="new-script">
+              <div className="new-page">
                 <input
-                  value={newScriptName}
-                  onChange={(e) => setNewScriptName(e.target.value)}
-                  placeholder="New script name"
+                  value={newPageName}
+                  onChange={(e) => setNewPageName(e.target.value)}
+                  placeholder="New page name"
                 />
-                <button onClick={handleCreateScript}>Add</button>
-                {scriptError && <p className="error">{scriptError}</p>}
+                <button onClick={handleCreatePage}>Add</button>
+                {pageError && <p className="error">{pageError}</p>}
               </div>
               <ul>
-                {scripts.length === 0 && <li>No scripts</li>}
-                {scripts.map((s) => (
+                {pages.length === 0 && <li>No pages</li>}
+                {pages.map((s) => (
                   <li
                     key={s}
-                    className={s === activeScript ? 'active-script' : ''}
+                    className={s === activePage ? 'active-page' : ''}
                   >
-                    <span onClick={() => handleSelectScript(s)}>{s}</span>
-                    <button onClick={() => handleDeleteScript(s)}>x</button>
+                    <span onClick={() => handleSelectPage(s)}>{s}</span>
+                    <button onClick={() => handleDeletePage(s)}>x</button>
                   </li>
                 ))}
               </ul>

--- a/src/style.css
+++ b/src/style.css
@@ -107,7 +107,7 @@ a {
   margin-bottom: 1rem;
 }
 
-.project-header .add-script-btn {
+.project-header .add-page-btn {
   border: none;
   background: none;
   color: var(--accent-color);
@@ -174,18 +174,18 @@ a {
   margin-left: 0.5rem;
 }
 
-.sidebar-content li.active-script {
+.sidebar-content li.active-page {
   font-weight: bold;
   color: var(--accent-color);
 }
 
-.new-script {
+.new-page {
   display: flex;
   gap: 0.25rem;
   margin-bottom: 0.5rem;
 }
 
-.new-script input {
+.new-page input {
   flex: 1;
 }
 

--- a/src/utils/pageRepository.js
+++ b/src/utils/pageRepository.js
@@ -1,6 +1,6 @@
 import { getSupabase } from './supabaseClient'
 
-const TABLE = 'scripts'
+const TABLE = 'pages'
 
 function handleUnauthorized(error) {
   if (error?.status === 401 || error?.message?.includes('not logged in')) {
@@ -19,7 +19,7 @@ async function getCurrentUserId(supabase) {
   return user.id
 }
 
-export async function listScripts(projectId) {
+export async function listPages(projectId) {
   try {
     const supabase = await getSupabase()
     const userId = await getCurrentUserId(supabase)
@@ -37,7 +37,7 @@ export async function listScripts(projectId) {
   }
 }
 
-export async function createScript(name, data, projectId) {
+export async function createPage(name, data, projectId) {
   try {
     const now = new Date().toISOString()
     const supabase = await getSupabase()
@@ -67,7 +67,7 @@ export async function createScript(name, data, projectId) {
   }
 }
 
-export async function readScript(name, projectId) {
+export async function readPage(name, projectId) {
   try {
     const supabase = await getSupabase()
     const userId = await getCurrentUserId(supabase)
@@ -94,9 +94,9 @@ export async function readScript(name, projectId) {
   }
 }
 
-export async function updateScript(name, data, projectId) {
+export async function updatePage(name, data, projectId) {
   try {
-    const existing = await readScript(name, projectId)
+    const existing = await readPage(name, projectId)
     if (!existing) return null
     const updated = {
       metadata: {
@@ -128,7 +128,7 @@ export async function updateScript(name, data, projectId) {
   }
 }
 
-export async function deleteScript(name, projectId) {
+export async function deletePage(name, projectId) {
   try {
     const supabase = await getSupabase()
     const userId = await getCurrentUserId(supabase)

--- a/supabase/migrations/20250803001429_add_user_id_to_pages_and_projects.sql
+++ b/supabase/migrations/20250803001429_add_user_id_to_pages_and_projects.sql
@@ -1,22 +1,22 @@
-alter table scripts
+alter table pages
   add column if not exists user_id uuid not null default auth.uid();
 
 alter table projects
   add column if not exists user_id uuid not null default auth.uid();
 
-alter table scripts enable row level security;
+alter table pages enable row level security;
 alter table projects enable row level security;
 
-create policy "scripts_select" on scripts
+create policy "pages_select" on pages
   for select using (user_id = auth.uid());
 
-create policy "scripts_insert" on scripts
+create policy "pages_insert" on pages
   for insert with check (user_id = auth.uid());
 
-create policy "scripts_update" on scripts
+create policy "pages_update" on pages
   for update using (user_id = auth.uid()) with check (user_id = auth.uid());
 
-create policy "scripts_delete" on scripts
+create policy "pages_delete" on pages
   for delete using (user_id = auth.uid());
 
 create policy "projects_select" on projects


### PR DESCRIPTION
## Summary
- rename Supabase `scripts` references to `pages`
- update repository logic and UI to use pages instead of scripts
- document `pages` table and update migrations

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688eca71d3dc83218b8f6c31b9896c8e