### PR TITLE
feat: add sidebar export and account options

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -31,6 +31,7 @@ function Sidebar({
     activePageProp ?? null,
   )
   const activePage = activePageProp ?? activePageState
+  const [exportScope, setExportScope] = useState('current')
 
   useEffect(() => {
     if (activePageProp !== undefined) {
@@ -118,6 +119,19 @@ function Sidebar({
     onSignOut?.()
   }
 
+  function handleExport(format) {
+    console.log(`Export ${exportScope} as ${format}`)
+  }
+
+  async function handleAccount() {
+    await handleSignOut()
+    console.log('Sign in placeholder')
+  }
+
+  function handleSettings() {
+    console.log('Settings placeholder')
+  }
+
   useImperativeHandle(ref, () => ({
     refreshPages,
     selectPage: handleSelectPage,
@@ -183,7 +197,25 @@ function Sidebar({
           )}
         </section>
         {renderAssets?.()}
-        <button onClick={handleSignOut}>Sign out</button>
+        <div className="additional-options">
+          <h4>Additional Options</h4>
+          <div className="export-section">
+            <select
+              value={exportScope}
+              onChange={(e) => setExportScope(e.target.value)}
+            >
+              <option value="current">Current Page</option>
+              <option value="selected">Selected Pages</option>
+              <option value="full">Full Document</option>
+            </select>
+            <div className="export-formats">
+              <button onClick={() => handleExport('PDF')}>PDF</button>
+              <button onClick={() => handleExport('Docx')}>Docx</button>
+            </div>
+          </div>
+          <button onClick={handleAccount}>Account</button>
+          <button onClick={handleSettings}>Settings</button>
+        </div>
       </div>
     </aside>
   )

--- a/src/style.css
+++ b/src/style.css
@@ -202,3 +202,24 @@ a {
   color: var(--text-color);
 }
 
+.additional-options {
+  border-top: 1px solid #333;
+  margin-top: 1rem;
+  padding-top: 1rem;
+  background: #181818;
+}
+
+.additional-options h4 {
+  margin: 0 0 0.5rem 0;
+}
+
+.additional-options .export-section {
+  margin-bottom: 1rem;
+}
+
+.additional-options .export-formats {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+


### PR DESCRIPTION
## Summary
- add Additional Options section with export dropdown and account/settings buttons
- style Additional Options section distinct from navigation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688ecfcf7fc08321b2557b8e3a843c88