### PR TITLE
Add mode carousel and pass mode to editor

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,6 @@
 /* global __APP_VERSION__ */
-import { useEditor, EditorContent } from '@tiptap/react'
+import { useEditor } from '@tiptap/react'
 import { useState, useRef } from 'react'
-import { BubbleMenu } from '@tiptap/react/menus'
 import StarterKit from '@tiptap/starter-kit'
 import SlashCommand from './extensions/SlashCommand'
 import SmartFlow from './extensions/SmartFlow'
@@ -14,6 +13,8 @@ import {
   NoCopy,
 } from './extensions/customNodes'
 import Sidebar from './components/Sidebar'
+import Editor from './components/Editor'
+import ModeCarousel from './components/ModeCarousel'
 import { createPage } from './utils/pageRepository'
 
 function ProjectHeader({ projectName, onAddPage, disabled }) {
@@ -34,6 +35,7 @@ function ProjectHeader({ projectName, onAddPage, disabled }) {
 export default function App({ onSignOut }) {
   const [pageTitle, setPageTitle] = useState('Untitled Page')
   const [activeProject, setActiveProject] = useState(null)
+  const [mode, setMode] = useState('Script')
   const sidebarRef = useRef(null)
   const currentPage = { content: '' }
   const editor = useEditor({
@@ -78,40 +80,14 @@ export default function App({ onSignOut }) {
         onSignOut={onSignOut}
       />
       <div className="editor-container">
+        <ModeCarousel currentMode={mode} onModeChange={setMode} />
         <ProjectHeader
           projectName={activeProject?.name}
           onAddPage={handleAddPage}
           disabled={!activeProject}
         />
         <h1 className="editor-title">{pageTitle}</h1>
-        {editor && (
-          <>
-            <BubbleMenu
-              className="bubble-menu"
-              editor={editor}
-            >
-              <button
-                onClick={() => editor.chain().focus().toggleBold().run()}
-                className={editor.isActive('bold') ? 'is-active' : ''}
-              >
-                B
-              </button>
-              <button
-                onClick={() => editor.chain().focus().toggleItalic().run()}
-                className={editor.isActive('italic') ? 'is-active' : ''}
-              >
-                I
-              </button>
-              <button
-                onClick={() => editor.chain().focus().toggleUnderline().run()}
-                className={editor.isActive('underline') ? 'is-active' : ''}
-              >
-                U
-              </button>
-            </BubbleMenu>
-            <EditorContent editor={editor} />
-          </>
-        )}
+        {editor && <Editor editor={editor} mode={mode} />}
       </div>
       <div className="app-name">Panelist v{__APP_VERSION__}</div>
     </div>

--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -1,0 +1,39 @@
+import { useEffect } from 'react'
+import { BubbleMenu } from '@tiptap/react/menus'
+import { EditorContent } from '@tiptap/react'
+
+export default function Editor({ editor, mode }) {
+  useEffect(() => {
+    if (mode) {
+      console.log(`Editor mode set to: ${mode}`)
+    }
+  }, [mode])
+
+  if (!editor) return null
+
+  return (
+    <>
+      <BubbleMenu className="bubble-menu" editor={editor}>
+        <button
+          onClick={() => editor.chain().focus().toggleBold().run()}
+          className={editor.isActive('bold') ? 'is-active' : ''}
+        >
+          B
+        </button>
+        <button
+          onClick={() => editor.chain().focus().toggleItalic().run()}
+          className={editor.isActive('italic') ? 'is-active' : ''}
+        >
+          I
+        </button>
+        <button
+          onClick={() => editor.chain().focus().toggleUnderline().run()}
+          className={editor.isActive('underline') ? 'is-active' : ''}
+        >
+          U
+        </button>
+      </BubbleMenu>
+      <EditorContent editor={editor} />
+    </>
+  )
+}

--- a/src/components/ModeCarousel.jsx
+++ b/src/components/ModeCarousel.jsx
@@ -1,0 +1,35 @@
+import { useRef } from 'react'
+
+const modes = ['Script', 'Tiles*', 'Animation*']
+
+export default function ModeCarousel({ currentMode, onModeChange }) {
+  const containerRef = useRef(null)
+
+  function handleSelect(mode) {
+    const isPlaceholder = mode.endsWith('*')
+    const cleanMode = mode.replace('*', '')
+    if (isPlaceholder) {
+      console.log(`${cleanMode} mode is coming soon`)
+      return
+    }
+    onModeChange?.(cleanMode)
+  }
+
+  return (
+    <div className="mode-carousel" ref={containerRef}>
+      {modes.map((mode) => {
+        const cleanMode = mode.replace('*', '')
+        const isActive = currentMode === cleanMode
+        return (
+          <button
+            key={mode}
+            className={isActive ? 'active' : ''}
+            onClick={() => handleSelect(mode)}
+          >
+            {mode}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/style.css
+++ b/src/style.css
@@ -194,6 +194,27 @@ a {
   margin: 0 0 1rem 0;
 }
 
+.mode-carousel {
+  display: flex;
+  overflow-x: auto;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.mode-carousel button {
+  background: none;
+  border: 1px solid #333;
+  color: var(--text-color);
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.mode-carousel button.active {
+  border-color: var(--accent-color);
+  color: var(--accent-color);
+}
+
 .app-name {
   position: fixed;
   bottom: 1rem;


### PR DESCRIPTION
## Summary
- add ModeCarousel to switch between modes with placeholder for unimplemented ones
- move editor UI into its own component and log selected mode
- wire up App with new mode state and styling for carousel

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688ecfced20c8321b35d014e34f1717b