### PR TITLE
Show active page and mode in editor header

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,8 @@ import {
   NoCopy,
 } from './extensions/customNodes'
 import Sidebar from './components/Sidebar'
+import ModeCarousel from './components/ModeCarousel'
+import PageNavigator from './components/PageNavigator'
 import { createPage } from './utils/pageRepository'
 import { updateScript } from './utils/scriptRepository'
 
@@ -33,9 +35,10 @@ function ProjectHeader({ projectName, onAddPage, disabled }) {
 }
 
 export default function App({ onSignOut }) {
-  const [scriptTitle, setScriptTitle] = useState('Untitled Script')
+  const [pageTitle, setPageTitle] = useState('Untitled Page')
   const [activeProject, setActiveProject] = useState(null)
   const [isSaving, setIsSaving] = useState(false)
+  const [mode, setMode] = useState('Write')
   const sidebarRef = useRef(null)
   const currentPage = { content: '' }
   const editor = useEditor({
@@ -67,7 +70,7 @@ export default function App({ onSignOut }) {
   }
 
   function handleSelectPage(name, data) {
-    setScriptTitle(name)
+    setPageTitle(name)
     editor?.commands?.setContent(data.content ?? '')
   }
 
@@ -80,7 +83,7 @@ export default function App({ onSignOut }) {
       timeoutId = setTimeout(async () => {
         if (activeProject) {
           await updateScript(
-            scriptTitle,
+            pageTitle,
             { content: editor.getHTML() },
             activeProject.id,
           )
@@ -93,7 +96,7 @@ export default function App({ onSignOut }) {
       editor.off('update', saveHandler)
       clearTimeout(timeoutId)
     }
-  }, [editor, scriptTitle, activeProject])
+  }, [editor, pageTitle, activeProject])
 
   return (
     <div className="app-layout">
@@ -109,8 +112,13 @@ export default function App({ onSignOut }) {
           onAddPage={handleAddPage}
           disabled={!activeProject}
         />
+        <ModeCarousel onModeChange={setMode} />
+        <PageNavigator
+          projectId={activeProject?.id}
+          onSelectPage={handleSelectPage}
+        />
         <h1 className="editor-title">
-          {scriptTitle}
+          {pageTitle} <span className="mode-display">({mode})</span>
           {isSaving && <span className="saving-indicator"> saving...</span>}
         </h1>
         {editor && (

--- a/src/components/ModeCarousel.jsx
+++ b/src/components/ModeCarousel.jsx
@@ -1,0 +1,30 @@
+import { useState, useEffect } from 'react'
+
+export default function ModeCarousel({ modes = ['Write', 'Preview'], onModeChange }) {
+  const [index, setIndex] = useState(0)
+  const currentMode = modes[index]
+
+  useEffect(() => {
+    onModeChange?.(currentMode)
+  }, [currentMode, onModeChange])
+
+  function prev() {
+    setIndex((i) => (i - 1 + modes.length) % modes.length)
+  }
+
+  function next() {
+    setIndex((i) => (i + 1) % modes.length)
+  }
+
+  return (
+    <div className="mode-carousel">
+      <button onClick={prev} disabled={modes.length <= 1}>
+        {'<'}
+      </button>
+      <span className="mode-label">{currentMode}</span>
+      <button onClick={next} disabled={modes.length <= 1}>
+        {'>'}
+      </button>
+    </div>
+  )
+}

--- a/src/components/PageNavigator.jsx
+++ b/src/components/PageNavigator.jsx
@@ -1,0 +1,50 @@
+import { useState, useEffect } from 'react'
+import { listPages, readPage } from '../utils/pageRepository'
+
+export default function PageNavigator({ projectId, onSelectPage }) {
+  const [pages, setPages] = useState([])
+  const [currentIndex, setCurrentIndex] = useState(0)
+
+  useEffect(() => {
+    if (!projectId) {
+      setPages([])
+      setCurrentIndex(0)
+      return
+    }
+    listPages(projectId).then((names) => {
+      setPages(names)
+      setCurrentIndex(0)
+    })
+  }, [projectId])
+
+  useEffect(() => {
+    if (pages.length === 0) return
+    const name = pages[currentIndex]
+    readPage(name, projectId).then((result) => {
+      const data = result?.data ?? result
+      onSelectPage?.(name, data)
+    })
+  }, [currentIndex, pages, projectId, onSelectPage])
+
+  function prev() {
+    if (pages.length === 0) return
+    setCurrentIndex((i) => (i - 1 + pages.length) % pages.length)
+  }
+
+  function next() {
+    if (pages.length === 0) return
+    setCurrentIndex((i) => (i + 1) % pages.length)
+  }
+
+  return (
+    <div className="page-navigator">
+      <button onClick={prev} disabled={pages.length <= 1}>
+        Prev
+      </button>
+      <span className="page-name">{pages[currentIndex] ?? 'No pages'}</span>
+      <button onClick={next} disabled={pages.length <= 1}>
+        Next
+      </button>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- rename script title state to page title and show selected mode
- add mode carousel and page navigator components
- sync page navigator selection with editor content

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run test:supabase` *(fails: Missing environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_688ecfd347248321ad8b72e435d45fb6