### PR TITLE
refactor: remove duplicate ModeCarousel

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
 /* global __APP_VERSION__ */
 import { useEditor } from '@tiptap/react'
-import { useState, useRef } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import StarterKit from '@tiptap/starter-kit'
 import SlashCommand from './extensions/SlashCommand'
 import SmartFlow from './extensions/SmartFlow'
@@ -113,7 +113,6 @@ export default function App({ onSignOut }) {
           onAddPage={handleAddPage}
           disabled={!activeProject}
         />
-        <ModeCarousel onModeChange={setMode} />
         <PageNavigator
           projectId={activeProject?.id}
           onSelectPage={handleSelectPage}


### PR DESCRIPTION
## Summary
- deduplicate ModeCarousel in editor container
- import useEffect to support autosave

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: pageNavigatorRef is not defined in Sidebar.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_688ed83bb19083219486ec1ac8fded19