### PR TITLE
style: add format guide styles

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,9 @@ import {
   Dialogue,
   Sfx,
   NoCopy,
+  CueLabel,
+  CueContent,
+  Notes,
 } from './extensions/customNodes'
 import Sidebar from './components/Sidebar'
 import Editor from './components/Editor'
@@ -32,6 +35,9 @@ export default function App({ onSignOut }) {
       Dialogue,
       Sfx,
       NoCopy,
+      CueLabel,
+      CueContent,
+      Notes,
       SmartFlow,
       SlashCommand,
     ],

--- a/src/extensions/SlashCommand.js
+++ b/src/extensions/SlashCommand.js
@@ -35,9 +35,32 @@ const SlashCommand = Extension.create({
               },
             },
             {
+              title: 'Cue Label',
+              command: ({ editor, range }) => {
+                editor.chain().focus().deleteRange(range).setCueLabel().run()
+              },
+            },
+            {
+              title: 'Cue Content',
+              command: ({ editor, range }) => {
+                editor
+                  .chain()
+                  .focus()
+                  .deleteRange(range)
+                  .setCueContent()
+                  .run()
+              },
+            },
+            {
               title: 'SFX',
               command: ({ editor, range }) => {
                 editor.chain().focus().deleteRange(range).setSfx().run()
+              },
+            },
+            {
+              title: 'Notes',
+              command: ({ editor, range }) => {
+                editor.chain().focus().deleteRange(range).setNotes().run()
               },
             },
             {

--- a/src/extensions/customNodes.js
+++ b/src/extensions/customNodes.js
@@ -28,7 +28,7 @@ export const PanelHeader = Node.create({
     return [{ tag: 'h2' }]
   },
   renderHTML({ HTMLAttributes }) {
-    return ['h2', mergeAttributes(HTMLAttributes), 0]
+    return ['h2', mergeAttributes(HTMLAttributes, { class: 'panel-header' }), 0]
   },
   addCommands() {
     return {
@@ -82,5 +82,20 @@ export const Sfx = paragraphNode({
 export const NoCopy = paragraphNode({
   name: 'noCopy',
   className: 'no-copy',
+})
+
+export const CueLabel = paragraphNode({
+  name: 'cueLabel',
+  className: 'cue-label',
+})
+
+export const CueContent = paragraphNode({
+  name: 'cueContent',
+  className: 'cue-content',
+})
+
+export const Notes = paragraphNode({
+  name: 'notes',
+  className: 'notes',
 })
 

--- a/src/index.css
+++ b/src/index.css
@@ -6,4 +6,48 @@
   body {
     @apply bg-zinc-900 text-zinc-100 antialiased;
   }
+  :root {
+    --tab-width: 4ch;
+  }
+}
+
+@layer components {
+  .panel-header {
+    font-family: 'Baskerville', serif;
+    font-weight: 700;
+    font-size: 14pt;
+    text-transform: uppercase;
+    margin-top: 24px;
+    margin-bottom: 12px;
+  }
+  .cue-label {
+    font-family: 'Courier New', monospace;
+    font-weight: 700;
+    font-size: 12pt;
+    text-transform: uppercase;
+    margin-left: calc(0 * var(--tab-width));
+    margin-bottom: 0;
+  }
+  .cue-content {
+    font-family: 'Courier New', monospace;
+    font-weight: 400;
+    font-size: 12pt;
+    margin-left: calc(2 * var(--tab-width));
+    margin-bottom: 8px;
+  }
+  .sfx {
+    font-family: 'Courier New', monospace;
+    font-style: italic;
+    font-size: 12pt;
+    margin-left: calc(2 * var(--tab-width));
+    margin-bottom: 8px;
+  }
+  .notes {
+    font-family: 'Courier New', monospace;
+    font-style: italic;
+    font-size: 12pt;
+    color: #888888;
+    margin-left: calc(1 * var(--tab-width));
+    margin-bottom: 8px;
+  }
 }


### PR DESCRIPTION
## Summary
- map panel header styling to Tiptap extension
- add cue label/content/notes extensions
- style editor nodes to match format guide

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f9ea10c6c8321a8992b37895c9a3e