### PR TITLE
feat: extend Tailwind with zinc

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,4 @@
+@config '../tailwind.config.js';
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,10 +1,15 @@
+import colors from 'tailwindcss/colors'
 import tailwindcssAnimate from 'tailwindcss-animate'
 
 export default {
   darkMode: 'class',
   content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        zinc: colors.zinc,
+      },
+    },
   },
   plugins: [tailwindcssAnimate],
 }


### PR DESCRIPTION
## Summary
- import Tailwind's color set and extend the theme with zinc shades
- reference Tailwind config in global styles so zinc utilities compile

## Testing
- `npm test` *(fails: missing script: "test")*
- `npm run lint`
- `npm run build`
- `grep -o "bg-zinc-[0-9]\+" dist/assets/index-DjQLpywQ.css`


------
https://chatgpt.com/codex/tasks/task_e_688fa3cf9a5483218bbb2e1560ae2d29