### PR TITLE
Add character-dialogue flow and panel header shortcut

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import {
   PageHeader,
   PanelHeader,
   Description,
+  Character,
   Dialogue,
   Sfx,
   NoCopy,
@@ -32,6 +33,7 @@ export default function App({ onSignOut }) {
       PageHeader,
       PanelHeader,
       Description,
+      Character,
       Dialogue,
       Sfx,
       NoCopy,
@@ -76,6 +78,13 @@ export default function App({ onSignOut }) {
       clearTimeout(timeoutId)
     }
   }, [editor, pageTitle, activeProject])
+
+  useEffect(() => {
+    if (!editor) return
+    editor.commands.setCharacterSuggestions(
+      activeProject?.characters ?? [],
+    )
+  }, [editor, activeProject])
 
   return (
     <div className="app-layout">

--- a/src/extensions/SlashCommand.js
+++ b/src/extensions/SlashCommand.js
@@ -29,6 +29,12 @@ const SlashCommand = Extension.create({
               },
             },
             {
+              title: 'Character',
+              command: ({ editor, range }) => {
+                editor.chain().focus().deleteRange(range).setCharacter().run()
+              },
+            },
+            {
               title: 'Dialogue',
               command: ({ editor, range }) => {
                 editor.chain().focus().deleteRange(range).setDialogue().run()

--- a/src/extensions/SmartFlow.js
+++ b/src/extensions/SmartFlow.js
@@ -1,10 +1,11 @@
-import { Extension } from '@tiptap/core'
+import { Extension, InputRule } from '@tiptap/core'
 
 const flowMap = {
   pageHeader: 'panelHeader',
   panelHeader: 'description',
-  description: 'dialogue',
-  dialogue: 'dialogue',
+  description: 'character',
+  character: 'dialogue',
+  dialogue: 'character',
   sfx: 'dialogue',
   noCopy: 'dialogue',
 }
@@ -27,10 +28,16 @@ const SmartFlow = Extension.create({
       },
       Tab: () => {
         const { $from } = this.editor.state.selection
+        const currentType = $from.parent.type.name
+        const nextType = flowMap[currentType]
         const nextPos = $from.after()
         const nextNode = this.editor.state.doc.nodeAt(nextPos)
-        if (!nextNode || isBoundary(nextNode.type.name)) return false
-        this.editor.commands.focus(nextPos)
+        if (nextNode && !isBoundary(nextNode.type.name)) {
+          this.editor.commands.focus(nextPos)
+          return true
+        }
+        if (!nextType) return false
+        this.editor.chain().focus().insertContent({ type: nextType }).run()
         return true
       },
       'Shift-Tab': () => {
@@ -42,6 +49,30 @@ const SmartFlow = Extension.create({
         return true
       },
     }
+  },
+  addInputRules() {
+    const panelRule = new InputRule({
+      find: /Panel--$/,
+      handler: ({ state, range, chain }) => {
+        let count = 0
+        state.doc.descendants(node => {
+          if (node.type.name === 'panelHeader') count++
+        })
+        const number = count + 1
+        chain()
+          .focus()
+          .deleteRange(range)
+          .insertContent([
+            {
+              type: 'panelHeader',
+              content: [{ type: 'text', text: `Panel ${number}` }],
+            },
+            { type: 'description' },
+          ])
+          .run()
+      },
+    })
+    return [panelRule]
   },
 })
 

--- a/src/extensions/customNodes.js
+++ b/src/extensions/customNodes.js
@@ -1,4 +1,5 @@
 import { Node, mergeAttributes } from '@tiptap/core'
+import Suggestion from '@tiptap/suggestion'
 
 export const PageHeader = Node.create({
   name: 'pageHeader',
@@ -72,6 +73,120 @@ export const Description = paragraphNode({
 export const Dialogue = paragraphNode({
   name: 'dialogue',
   className: 'dialogue',
+})
+
+export const Character = Node.create({
+  name: 'character',
+  group: 'block',
+  content: 'inline*',
+  addOptions() {
+    return {
+      suggestion: {
+        char: '',
+        startOfLine: true,
+        allowSpaces: true,
+        items: ({ query }) => {
+          const list =
+            this.editor?.storage?.character?.suggestions ?? []
+          return list
+            .filter(item =>
+              item.toLowerCase().startsWith(query.toLowerCase()),
+            )
+            .slice(0, 5)
+        },
+        command: ({ editor, range, props }) => {
+          editor
+            .chain()
+            .focus()
+            .deleteRange(range)
+            .insertContent(props)
+            .run()
+        },
+        render: () => {
+          let element
+
+          const renderItems = props => {
+            element.innerHTML = ''
+
+            props.items.forEach((item, index) => {
+              const div = document.createElement('div')
+              div.className = 'slash-command-item'
+              if (index === props.selected) {
+                div.classList.add('is-selected')
+              }
+              div.textContent = item
+              div.addEventListener('mousedown', event => {
+                event.preventDefault()
+                props.command(item)
+              })
+              element.append(div)
+            })
+          }
+
+          return {
+            onStart: props => {
+              element = document.createElement('div')
+              element.className = 'slash-command-menu'
+              renderItems(props)
+
+              const { top, left } = props.clientRect()
+              element.style.top = `${top + window.scrollY}px`
+              element.style.left = `${left + window.scrollX}px`
+              document.body.appendChild(element)
+            },
+            onUpdate(props) {
+              renderItems(props)
+              const { top, left } = props.clientRect()
+              element.style.top = `${top + window.scrollY}px`
+              element.style.left = `${left + window.scrollX}px`
+            },
+            onKeyDown(props) {
+              if (props.event.key === 'Escape') {
+                element.remove()
+                return true
+              }
+              return false
+            },
+            onExit() {
+              element.remove()
+            },
+          }
+        },
+      },
+    }
+  },
+  addStorage() {
+    return {
+      suggestions: [],
+    }
+  },
+  parseHTML() {
+    return [{ tag: 'p.character' }]
+  },
+  renderHTML({ HTMLAttributes }) {
+    return [
+      'p',
+      mergeAttributes(HTMLAttributes, { class: 'character' }),
+      0,
+    ]
+  },
+  addCommands() {
+    return {
+      setCharacter:
+        () =>
+        ({ commands }) =>
+          commands.insertContent({ type: this.name }),
+      setCharacterSuggestions:
+        suggestions =>
+        ({ editor }) => {
+          editor.storage.character.suggestions = suggestions
+          return true
+        },
+    }
+  },
+  addProseMirrorPlugins() {
+    return [Suggestion({ editor: this.editor, ...this.options.suggestion })]
+  },
 })
 
 export const Sfx = paragraphNode({

--- a/src/index.css
+++ b/src/index.css
@@ -232,6 +232,23 @@ body {
   margin-bottom: 12px;
 }
 
+.character {
+  font-family: 'Courier New', monospace;
+  font-weight: 700;
+  font-size: 12pt;
+  text-transform: uppercase;
+  margin-left: calc(2 * var(--tab-width));
+  margin-bottom: 0;
+}
+
+.dialogue {
+  font-family: 'Courier New', monospace;
+  font-weight: 400;
+  font-size: 12pt;
+  margin-left: calc(2 * var(--tab-width));
+  margin-bottom: 8px;
+}
+
 .cue-label {
   font-family: 'Courier New', monospace;
   font-weight: 700;


### PR DESCRIPTION
## Summary
- add Character node with project-based suggestions
- cycle Tab/Enter between character and dialogue
- insert next panel header when typing `Panel--`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fe28bec208321b566c5959da30c96