### PR TITLE
feat: add script page schema and serialization

### DIFF
--- a/src/extensions/customNodes.js
+++ b/src/extensions/customNodes.js
@@ -1,9 +1,32 @@
 import { Node, mergeAttributes } from '@tiptap/core'
 
 export const PageHeader = Node.create({
+  /**
+   * Page header containing page level metadata.
+   *
+   * Required attributes:
+   * - page: page number
+   * - panel_count: total number of panels on the page
+   */
   name: 'pageHeader',
   group: 'block',
   content: 'inline*',
+  addAttributes() {
+    return {
+      page: {
+        default: 1,
+        parseHTML: element =>
+          parseInt(element.getAttribute('data-page') || '1', 10),
+        renderHTML: attrs => ({ 'data-page': attrs.page }),
+      },
+      panel_count: {
+        default: 0,
+        parseHTML: element =>
+          parseInt(element.getAttribute('data-panel_count') || '0', 10),
+        renderHTML: attrs => ({ 'data-panel_count': attrs.panel_count }),
+      },
+    }
+  },
   parseHTML() {
     return [{ tag: 'h1' }]
   },
@@ -21,9 +44,25 @@ export const PageHeader = Node.create({
 })
 
 export const PanelHeader = Node.create({
+  /**
+   * Marks the beginning of a panel.
+   *
+   * Required attributes:
+   * - panel_number: sequential index of the panel
+   */
   name: 'panelHeader',
   group: 'block',
   content: 'inline*',
+  addAttributes() {
+    return {
+      panel_number: {
+        default: 1,
+        parseHTML: element =>
+          parseInt(element.getAttribute('data-panel_number') || '1', 10),
+        renderHTML: attrs => ({ 'data-panel_number': attrs.panel_number }),
+      },
+    }
+  },
   parseHTML() {
     return [{ tag: 'h2' }]
   },
@@ -40,11 +79,14 @@ export const PanelHeader = Node.create({
   },
 })
 
-function paragraphNode({ name, className }) {
+function paragraphNode({ name, className, attrs = {} }) {
   return Node.create({
     name,
     group: 'block',
     content: 'inline*',
+    addAttributes() {
+      return attrs
+    },
     parseHTML() {
       return [{ tag: `p.${className}` }]
     },
@@ -72,16 +114,40 @@ export const Description = paragraphNode({
 export const Dialogue = paragraphNode({
   name: 'dialogue',
   className: 'dialogue',
+  attrs: {
+    /** Cue type for dialogue nodes */
+    type: {
+      default: 'CHARACTER',
+      parseHTML: element => element.getAttribute('data-type') || 'CHARACTER',
+      renderHTML: attrs => ({ 'data-type': attrs.type }),
+    },
+  },
 })
 
 export const Sfx = paragraphNode({
   name: 'sfx',
   className: 'sfx',
+  attrs: {
+    /** Cue type for sound effects */
+    type: {
+      default: 'SFX',
+      parseHTML: element => element.getAttribute('data-type') || 'SFX',
+      renderHTML: attrs => ({ 'data-type': attrs.type }),
+    },
+  },
 })
 
 export const NoCopy = paragraphNode({
   name: 'noCopy',
   className: 'no-copy',
+  attrs: {
+    /** Cue type representing omitted copy */
+    type: {
+      default: 'NO_COPY',
+      parseHTML: element => element.getAttribute('data-type') || 'NO_COPY',
+      renderHTML: attrs => ({ 'data-type': attrs.type }),
+    },
+  },
 })
 
 export const CueLabel = paragraphNode({
@@ -92,6 +158,14 @@ export const CueLabel = paragraphNode({
 export const CueContent = paragraphNode({
   name: 'cueContent',
   className: 'cue-content',
+  attrs: {
+    /** Cue type for generic content such as captions */
+    type: {
+      default: 'CAPTION',
+      parseHTML: element => element.getAttribute('data-type') || 'CAPTION',
+      renderHTML: attrs => ({ 'data-type': attrs.type }),
+    },
+  },
 })
 
 export const Notes = paragraphNode({

--- a/src/types/samplePage.ts
+++ b/src/types/samplePage.ts
@@ -1,0 +1,28 @@
+export interface Cue {
+  /** Cue type, e.g. CHARACTER, SFX, NARRATION, CAPTION */
+  type: string;
+  /** Displayed cue label */
+  label: string;
+  /** Text content associated with the cue */
+  content: string;
+}
+
+export interface Panel {
+  /** Sequential panel number starting at 1 */
+  panel_number: number;
+  /** Panel heading followed by optional description */
+  header: string;
+  /** Ordered list of cues within the panel */
+  cues: Cue[];
+  /** Optional notes for the panel */
+  notes?: string;
+}
+
+export interface ScriptPage {
+  /** Page number */
+  page: number;
+  /** Number of panels on the page */
+  panel_count: number;
+  /** Panels contained in the page */
+  panels: Panel[];
+}

--- a/src/utils/serialization.ts
+++ b/src/utils/serialization.ts
@@ -1,0 +1,117 @@
+import type { JSONContent } from '@tiptap/core'
+import type { ScriptPage, Panel, Cue } from '../types/samplePage'
+
+function getText(node?: JSONContent): string {
+  if (!node?.content) return ''
+  return node.content.map((child: any) => child.text ?? '').join('')
+}
+
+/**
+ * Convert a Tiptap JSON document into a {@link ScriptPage}.
+ */
+export function toScriptPage(doc: JSONContent): ScriptPage {
+  const pageHeader = doc.content?.find(n => n.type === 'pageHeader')
+  const page = pageHeader?.attrs?.page ?? 1
+  const panelCount = pageHeader?.attrs?.panel_count ?? 0
+
+  const panels: (Panel & { pendingLabel?: string })[] = []
+  let current: (Panel & { pendingLabel?: string }) | null = null
+
+  for (const node of doc.content ?? []) {
+    switch (node.type) {
+      case 'panelHeader':
+        if (current) panels.push(current)
+        current = {
+          panel_number: node.attrs?.panel_number ?? panels.length + 1,
+          header: getText(node),
+          cues: [],
+        }
+        break
+      case 'description':
+        if (current) {
+          const desc = getText(node)
+          current.header = current.header ? `${current.header}: ${desc}` : desc
+        }
+        break
+      case 'cueLabel':
+        if (current) current.pendingLabel = getText(node)
+        break
+      case 'dialogue':
+      case 'sfx':
+      case 'cueContent':
+        if (current && current.pendingLabel) {
+          const cue: Cue = {
+            type: node.attrs?.type ?? current.pendingLabel.toUpperCase(),
+            label: current.pendingLabel,
+            content: getText(node),
+          }
+          current.cues.push(cue)
+          delete current.pendingLabel
+        }
+        break
+      case 'notes':
+        if (current) current.notes = getText(node)
+        break
+      default:
+        break
+    }
+  }
+  if (current) panels.push(current)
+
+  return {
+    page,
+    panel_count: panelCount || panels.length,
+    panels: panels.map(({ pendingLabel, ...rest }) => rest),
+  }
+}
+
+/**
+ * Build a Tiptap JSON document from a {@link ScriptPage}.
+ */
+export function fromScriptPage(page: ScriptPage): JSONContent {
+  const content: JSONContent[] = []
+  content.push({
+    type: 'pageHeader',
+    attrs: { page: page.page, panel_count: page.panel_count },
+    content: [],
+  })
+
+  for (const panel of page.panels) {
+    const [headerText, ...descParts] = panel.header.split(':')
+    content.push({
+      type: 'panelHeader',
+      attrs: { panel_number: panel.panel_number },
+      content: [{ type: 'text', text: headerText.trim() }],
+    })
+    const desc = descParts.join(':').trim()
+    if (desc) {
+      content.push({
+        type: 'description',
+        content: [{ type: 'text', text: desc }],
+      })
+    }
+    for (const cue of panel.cues) {
+      content.push({
+        type: 'cueLabel',
+        attrs: { label: cue.label },
+        content: [{ type: 'text', text: cue.label }],
+      })
+      let nodeType = 'cueContent'
+      if (cue.type === 'SFX') nodeType = 'sfx'
+      else if (cue.type === 'CHARACTER') nodeType = 'dialogue'
+      content.push({
+        type: nodeType,
+        attrs: { type: cue.type },
+        content: [{ type: 'text', text: cue.content }],
+      })
+    }
+    if (panel.notes) {
+      content.push({
+        type: 'notes',
+        content: [{ type: 'text', text: panel.notes }],
+      })
+    }
+  }
+
+  return { type: 'doc', content }
+}


### PR DESCRIPTION
## Summary
- define TypeScript interfaces for script pages
- document required attributes and add them to Tiptap nodes
- provide utilities to convert between Tiptap JSON and page schema

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fe074525c8321921a091be4fe1505