### PR TITLE
fix: check out main before version bump

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -16,6 +16,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Checkout latest main
+        run: |
+          git fetch origin main
+          git checkout -B main origin/main
+
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary
- fetch and checkout the latest `main` branch before running version bump workflow

## Testing
- `npm test` *(fails: missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fe1da75848321942cbd899d2123f9