### PR TITLE
Add unique plugin keys for suggestion-based extensions

### DIFF
--- a/src/extensions/SlashCommand.js
+++ b/src/extensions/SlashCommand.js
@@ -1,5 +1,6 @@
 import { Extension } from '@tiptap/core'
 import Suggestion from '@tiptap/suggestion'
+import { PluginKey } from 'prosemirror-state'
 
 const SlashCommand = Extension.create({
   name: 'slash-command',
@@ -133,7 +134,13 @@ const SlashCommand = Extension.create({
     }
   },
   addProseMirrorPlugins() {
-    return [Suggestion({ editor: this.editor, ...this.options.suggestion })]
+    return [
+      Suggestion({
+        editor: this.editor,
+        pluginKey: new PluginKey('slashCommandSuggestion'),
+        ...this.options.suggestion,
+      }),
+    ]
   },
 })
 

--- a/src/extensions/customNodes.js
+++ b/src/extensions/customNodes.js
@@ -1,5 +1,6 @@
 import { Node, mergeAttributes } from '@tiptap/core'
 import Suggestion from '@tiptap/suggestion'
+import { PluginKey } from 'prosemirror-state'
 
 export const PageHeader = Node.create({
   /**
@@ -235,7 +236,13 @@ export const Character = Node.create({
     }
   },
   addProseMirrorPlugins() {
-    return [Suggestion({ editor: this.editor, ...this.options.suggestion })]
+    return [
+      Suggestion({
+        editor: this.editor,
+        pluginKey: new PluginKey('characterSuggestion'),
+        ...this.options.suggestion,
+      }),
+    ]
   },
 })
 


### PR DESCRIPTION
## Summary
- assign `PluginKey` instances to SlashCommand and Character suggestions to avoid duplicate plugin conflicts
- import `PluginKey` from `prosemirror-state`

## Testing
- `npm run lint`
- `npm run build`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_688ff89cfa508321a409ade4a1e75660