### PR TITLE
Ensure ProseMirror fills editor container

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -146,6 +146,11 @@ body {
   box-shadow: 0 0 15px rgba(0, 0, 0, 0.4);
 }
 
+.editor-content .ProseMirror {
+  min-height: 100%;
+  height: 100%;
+}
+
 /* Login */
 .login-container {
   margin: 5rem auto 0;


### PR DESCRIPTION
## Summary
- expand the ProseMirror editor to fill the `.editor-content` container by assigning full height

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6891473b6858832188a0b2144bdf678d