### PR TITLE
feat: add developer info window

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,6 +19,7 @@ import {
 import Sidebar from './components/Sidebar'
 import Editor from './components/Editor'
 import ModeCarousel from './components/ModeCarousel'
+import DevInfo from './components/DevInfo'
 import { updateScript } from './utils/scriptRepository'
 
 export default function App({ onSignOut }) {
@@ -26,6 +27,8 @@ export default function App({ onSignOut }) {
   const [activeProject, setActiveProject] = useState(null)
   const [isSaving, setIsSaving] = useState(false)
   const [mode, setMode] = useState('Write')
+  const [totalPages, setTotalPages] = useState(0)
+  const [wordCount, setWordCount] = useState(0)
   const currentPage = { content: '' }
   const editor = useEditor({
     extensions: [
@@ -50,9 +53,20 @@ export default function App({ onSignOut }) {
     setActiveProject(data)
   }
 
+  function countWords(text) {
+    return text ? text.trim().split(/\s+/).filter(Boolean).length : 0
+  }
+
   function handleSelectPage(name, data) {
     setPageTitle(name)
-    editor?.commands?.setContent(data.content ?? '')
+    const content = data.content ?? ''
+    editor?.commands?.setContent(content)
+    const text = content.replace(/<[^>]+>/g, ' ')
+    setWordCount(countWords(text))
+  }
+
+  function handlePagesChange(pages) {
+    setTotalPages(pages.length)
   }
 
   useEffect(() => {
@@ -81,6 +95,16 @@ export default function App({ onSignOut }) {
 
   useEffect(() => {
     if (!editor) return
+    const countHandler = () => setWordCount(countWords(editor.getText()))
+    editor.on('update', countHandler)
+    countHandler()
+    return () => {
+      editor.off('update', countHandler)
+    }
+  }, [editor])
+
+  useEffect(() => {
+    if (!editor) return
     editor.commands.setCharacterSuggestions(
       activeProject?.characters ?? [],
     )
@@ -92,6 +116,7 @@ export default function App({ onSignOut }) {
         onSelectProject={handleSelectProject}
         onSelectPage={handleSelectPage}
         onSignOut={onSignOut}
+        onPagesChange={handlePagesChange}
       />
       <div className="main-content">
         <ModeCarousel currentMode={mode} onModeChange={setMode} />
@@ -99,6 +124,12 @@ export default function App({ onSignOut }) {
         {editor && <Editor editor={editor} mode={mode} />}
         {isSaving && <span className="save-indicator"> saving...</span>}
       </div>
+      <DevInfo
+        projectName={activeProject?.name}
+        currentPage={pageTitle}
+        totalPages={totalPages}
+        wordCount={wordCount}
+      />
       <div className="version">Panelist v{__APP_VERSION__}</div>
     </div>
   )

--- a/src/components/DevInfo.jsx
+++ b/src/components/DevInfo.jsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+export default function DevInfo({ projectName, currentPage, totalPages, wordCount }) {
+  return (
+    <div className="dev-info">
+      <div>Project: {projectName || 'None'}</div>
+      <div>Page: {currentPage || 'None'}</div>
+      <div>Total Pages: {totalPages}</div>
+      <div>Total Words: {wordCount}</div>
+    </div>
+  )
+}

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -12,7 +12,7 @@ import { Button } from './ui/button'
 import { cn } from '../lib/utils'
 
 const PageNavigator = forwardRef(function PageNavigator(
-  { projectId, activePage, onSelectPage },
+  { projectId, activePage, onSelectPage, onPagesChange },
   ref,
 ) {
   const [pages, setPages] = useState([])
@@ -20,6 +20,7 @@ const PageNavigator = forwardRef(function PageNavigator(
   async function refresh(id = projectId) {
     if (!id) {
       setPages([])
+      onPagesChange?.([])
       return
     }
     const names = await listScripts(id)
@@ -33,6 +34,7 @@ const PageNavigator = forwardRef(function PageNavigator(
       }),
     )
     setPages(enriched)
+    onPagesChange?.(enriched)
   }
 
   useEffect(() => {
@@ -67,7 +69,10 @@ const PageNavigator = forwardRef(function PageNavigator(
   )
 })
 
-function Sidebar({ onSelectPage, onSelectProject, onSignOut }, ref) {
+function Sidebar(
+  { onSelectPage, onSelectProject, onSignOut, onPagesChange },
+  ref,
+) {
   const [projects, setProjects] = useState([])
   const [selectedProject, setSelectedProject] = useState(null)
   const [activePage, setActivePage] = useState(null)
@@ -154,6 +159,7 @@ function Sidebar({ onSelectPage, onSelectProject, onSignOut }, ref) {
           projectId={selectedProject.id}
           activePage={activePage}
           onSelectPage={handleSelectPage}
+          onPagesChange={onPagesChange}
         />
       )}
       <div className="signout-container">

--- a/src/index.css
+++ b/src/index.css
@@ -292,3 +292,13 @@ body {
   margin-bottom: 8px;
 }
 
+.dev-info {
+  position: fixed;
+  bottom: 1rem;
+  left: 1rem;
+  background: #27272a;
+  padding: 0.5rem;
+  font-size: 0.75rem;
+  color: #a1a1aa;
+  border-radius: 0.375rem;
+}


### PR DESCRIPTION
## Summary
- display active project, page count, and word total in a persistent dev window
- track word count and page list in app state
- style a fixed bottom-left overlay for debugging

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689148fcfe4883219533b082921fe35f