### PR TITLE
Clarify page content source and streamline editor updates

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,7 +30,6 @@ export default function App({ onSignOut }) {
   const currentPage = { page_content: '' }
   const [totalPages, setTotalPages] = useState(0)
   const [wordCount, setWordCount] = useState(0)
-  const currentPage = { content: '' }
   const editor = useEditor({
     extensions: [
       StarterKit,
@@ -60,11 +59,11 @@ export default function App({ onSignOut }) {
 
   function handleSelectPage(name, data) {
     setPageTitle(name)
-    editor?.commands?.setContent(data.page_content ?? '')
-    const content = data.content ?? ''
-    editor?.commands?.setContent(content)
-    const text = content.replace(/<[^>]+>/g, ' ')
-    setWordCount(countWords(text))
+    const pageContent = data.page_content ?? data.content ?? ''
+    if (editor) {
+      editor.commands.setContent(pageContent)
+      setWordCount(countWords(editor.getText()))
+    }
   }
 
   function handlePagesChange(pages) {


### PR DESCRIPTION
## Summary
- Treat `page_content` as the canonical page body, falling back to legacy `content` when needed
- Remove redundant `setContent` calls and compute word count from editor text

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68914bf6944c83219571d2836e8e1ceb