### PR TITLE
fix: unify currentPage field

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,7 +30,6 @@ export default function App({ onSignOut }) {
   const currentPage = { page_content: '' }
   const [totalPages, setTotalPages] = useState(0)
   const [wordCount, setWordCount] = useState(0)
-  const currentPage = { content: '' }
   const editor = useEditor({
     extensions: [
       StarterKit,
@@ -60,8 +59,7 @@ export default function App({ onSignOut }) {
 
   function handleSelectPage(name, data) {
     setPageTitle(name)
-    editor?.commands?.setContent(data.page_content ?? '')
-    const content = data.content ?? ''
+    const content = data.page_content ?? ''
     editor?.commands?.setContent(content)
     const text = content.replace(/<[^>]+>/g, ' ')
     setWordCount(countWords(text))


### PR DESCRIPTION
## Summary
- remove duplicate `currentPage` declarations
- use consistent `page_content` field when initializing the editor and selecting pages

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68914bf1de1c8321bb6a965f676ada50