### PR TITLE
Enable creating new pages from sidebar

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,7 +27,7 @@ export default function App({ onSignOut }) {
   const [activeProject, setActiveProject] = useState(null)
   const [isSaving, setIsSaving] = useState(false)
   const [mode, setMode] = useState('Write')
-  const [pageContent, setPageContent] = useState('')
+  const [pageContent, _setPageContent] = useState('')
   const [totalPages, setTotalPages] = useState(0)
   const [wordCount, setWordCount] = useState(0)
   const editor = useEditor({

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -5,7 +5,7 @@ import {
   useImperativeHandle,
   useRef,
 } from 'react'
-import { listScripts, readScript } from '../utils/scriptRepository'
+import { listScripts, readScript, createScript } from '../utils/scriptRepository'
 import { listProjects, createProject, readProject } from '../utils/projectRepository'
 import { signOut } from '../utils/auth.js'
 import { Button } from './ui/button'
@@ -39,6 +39,18 @@ const PageNavigator = forwardRef(function PageNavigator(
     return enriched
   }
 
+  async function handleCreatePage() {
+    const name = prompt('New page name')?.trim()
+    if (!name) return
+    try {
+      await createScript(name, {}, projectId)
+      await refresh()
+      onSelectPage(name)
+    } catch (err) {
+      console.error('Error creating page:', err)
+    }
+  }
+
   useEffect(() => {
     refresh()
   }, [projectId])
@@ -63,7 +75,7 @@ const PageNavigator = forwardRef(function PageNavigator(
       </ul>
       <Button
         className="new-page-button full-width"
-        onClick={() => console.log('New Page placeholder')}
+        onClick={handleCreatePage}
       >
         + New Page
       </Button>

--- a/src/utils/scriptRepository.js
+++ b/src/utils/scriptRepository.js
@@ -4,6 +4,7 @@ import {
   updatePage,
   loadPageContent,
   savePageContent,
+  createPage,
 } from './pageRepository'
 
 export async function listScripts(projectId) {
@@ -16,6 +17,10 @@ export async function readScript(name, projectId) {
 
 export async function updateScript(name, data, projectId) {
   return updatePage(name, data, projectId)
+}
+
+export async function createScript(name, data, projectId) {
+  return createPage(name, data, projectId)
 }
 
 export async function loadScriptContent(name, projectId) {


### PR DESCRIPTION
## Summary
- add `createScript` helper mapped to `createPage`
- wire sidebar's New Page button to create and load scripts
- silence unused state setter warning in `App`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68914ee215348321ac3cd98c70b47110