### PR TITLE
Validate page operations

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -78,11 +78,15 @@ export default function App({ onSignOut }) {
       clearTimeout(timeoutId)
       timeoutId = setTimeout(async () => {
         if (activeProject) {
-          await updateScript(
-            pageTitle,
-            { page_content: editor.getJSON(), metadata: { version: 1 } },
-            activeProject.id,
-          )
+          try {
+            await updateScript(
+              pageTitle,
+              { page_content: editor.getJSON(), metadata: { version: 1 } },
+              activeProject.id,
+            )
+          } catch (err) {
+            console.error('Error saving page:', err)
+          }
         }
         setIsSaving(false)
       }, 500)

--- a/src/utils/pageRepository.js
+++ b/src/utils/pageRepository.js
@@ -70,6 +70,8 @@ export async function createPage(name, data, projectId) {
 }
 
 export async function readPage(name, projectId) {
+  if (!name) throw new Error('title required')
+  if (!projectId) throw new Error('projectId required')
   try {
     const supabase = await getSupabase()
     const userId = await getCurrentUserId(supabase)
@@ -98,6 +100,8 @@ export async function readPage(name, projectId) {
 }
 
 export async function updatePage(name, data, projectId) {
+  if (!name) throw new Error('title required')
+  if (!projectId) throw new Error('projectId required')
   try {
     const existing = await readPage(name, projectId)
     if (!existing) return null
@@ -105,7 +109,7 @@ export async function updatePage(name, data, projectId) {
       metadata: {
         ...existing.metadata,
         ...data.metadata,
-        projectId: projectId ?? existing.metadata.projectId,
+        projectId: projectId,
         updated_at: new Date().toISOString(),
       },
       page_content: data.page_content ?? existing.page_content,
@@ -125,7 +129,7 @@ export async function updatePage(name, data, projectId) {
       .update(row)
       .eq('title', name)
       .eq('user_id', userId)
-      .eq('project_id', projectId ?? existing.metadata.projectId)
+      .eq('project_id', projectId)
     if (error) throw error
   } catch (error) {
     if (!handleUnauthorized(error)) throw error
@@ -133,6 +137,8 @@ export async function updatePage(name, data, projectId) {
 }
 
 export async function deletePage(name, projectId) {
+  if (!name) throw new Error('title required')
+  if (!projectId) throw new Error('projectId required')
   try {
     const supabase = await getSupabase()
     const userId = await getCurrentUserId(supabase)


### PR DESCRIPTION
## Summary
- enforce title and projectId when reading, updating or deleting pages
- catch page repository errors in Sidebar navigation
- handle save errors in the editor

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68915baa81588321b29cdd6225ac31ce