### PR TITLE
Wrap supabase calls in try catch

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -77,14 +77,20 @@ export default function App({ onSignOut }) {
       setIsSaving(true)
       clearTimeout(timeoutId)
       timeoutId = setTimeout(async () => {
-        if (activeProject) {
-          await updateScript(
-            pageTitle,
-            { page_content: editor.getJSON(), metadata: { version: 1 } },
-            activeProject.id,
-          )
+        try {
+          if (activeProject) {
+            await updateScript(
+              pageTitle,
+              { page_content: editor.getJSON(), metadata: { version: 1 } },
+              activeProject.id,
+            )
+          }
+        } catch (error) {
+          console.error('updateScript failed:', error.message)
+          console.warn('Autosave failed')
+        } finally {
+          setIsSaving(false)
         }
-        setIsSaving(false)
       }, 500)
     }
     editor.on('update', saveHandler)


### PR DESCRIPTION
## Summary
- handle Supabase calls with try/catch and console warnings in Sidebar
- guard autosave updateScript in App with error handling

## Testing
- `npm run lint`
- `npm run test:supabase` *(fails: Missing VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY environment variables.)*

------
https://chatgpt.com/codex/tasks/task_e_68915c20842c8321a326590863b088ea