### PR TITLE
Encode page titles for consistent lookups

### DIFF
--- a/src/utils/pageRepository.js
+++ b/src/utils/pageRepository.js
@@ -2,6 +2,18 @@ import { getSupabase } from './supabaseClient'
 
 const TABLE = 'pages'
 
+function encodeTitle(name) {
+  return encodeURIComponent(name)
+}
+
+function decodeTitle(name) {
+  try {
+    return decodeURIComponent(name)
+  } catch {
+    return name
+  }
+}
+
 function handleUnauthorized(error) {
   if (error?.status === 401 || error?.message?.includes('not logged in')) {
     window.location.reload()
@@ -30,7 +42,7 @@ export async function listPages(projectId) {
       .eq('project_id', projectId)
       .order('title')
     if (error) throw error
-    return data ? data.map((row) => row.title) : []
+    return data ? data.map((row) => decodeTitle(row.title)) : []
   } catch (error) {
     if (!handleUnauthorized(error)) throw error
     return []
@@ -43,7 +55,7 @@ export async function createPage(name, data, projectId) {
     const supabase = await getSupabase()
     const userId = await getCurrentUserId(supabase)
     const payload = {
-      title: name,
+      title: encodeTitle(name),
       created_at: now,
       updated_at: now,
       page_content: data.page_content ?? null,
@@ -55,7 +67,7 @@ export async function createPage(name, data, projectId) {
     if (error) throw error
     return {
       metadata: {
-        title: payload.title,
+        title: name,
         projectId: payload.project_id,
         created_at: payload.created_at,
         updated_at: payload.updated_at,
@@ -76,14 +88,14 @@ export async function readPage(name, projectId) {
     const { data, error } = await supabase
       .from(TABLE)
       .select('title, project_id, created_at, updated_at, page_content, version')
-      .eq('title', name)
+      .eq('title', encodeTitle(name))
       .eq('user_id', userId)
       .eq('project_id', projectId)
       .single()
     if (error) throw error
     return {
       metadata: {
-        title: data.title,
+        title: decodeTitle(data.title),
         projectId: data.project_id,
         created_at: data.created_at,
         updated_at: data.updated_at,
@@ -111,7 +123,7 @@ export async function updatePage(name, data, projectId) {
       page_content: data.page_content ?? existing.page_content,
     }
     const row = {
-      title: updated.metadata.title,
+      title: encodeTitle(updated.metadata.title),
       project_id: updated.metadata.projectId,
       created_at: updated.metadata.created_at,
       updated_at: updated.metadata.updated_at,
@@ -123,7 +135,7 @@ export async function updatePage(name, data, projectId) {
     const { error } = await supabase
       .from(TABLE)
       .update(row)
-      .eq('title', name)
+      .eq('title', encodeTitle(name))
       .eq('user_id', userId)
       .eq('project_id', projectId ?? existing.metadata.projectId)
     if (error) throw error
@@ -139,7 +151,7 @@ export async function deletePage(name, projectId) {
     const { error } = await supabase
       .from(TABLE)
       .delete()
-      .eq('title', name)
+      .eq('title', encodeTitle(name))
       .eq('user_id', userId)
       .eq('project_id', projectId)
     if (error) throw error


### PR DESCRIPTION
## Summary
- sanitize page titles with encode/decode helpers
- use encoded titles for all Supabase page CRUD operations

## Testing
- `npm run lint`
- `npm run test:supabase` *(fails: Missing VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68915c29681083219276d449aa048f1c