### PR TITLE
refactor: rename Editor to ScriptEditor

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If you are developing a production application, we recommend using TypeScript wi
 
 The `SmartFlow` extension adds keyboard shortcuts for navigating script panels.
 
-1. Run `npm run dev` and open the editor.
+1. Run `npm run dev` and open the ScriptEditor.
 2. Create a `PageHeader` node. Press **Enter** to insert the next node (`PanelHeader`), then **Enter** again to continue through the flow (`Description` → `Dialogue`).
 3. Use **Tab** to move the cursor forward through nodes in the current panel.
 4. Use **Shift+Tab** to move the cursor backward within the panel.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,7 +17,7 @@ import {
   Notes,
 } from './extensions/customNodes'
 import Sidebar from './components/Sidebar'
-import Editor from './components/Editor'
+import ScriptEditor from './components/ScriptEditor'
 import ModeCarousel from './components/ModeCarousel'
 import DevInfo from './components/DevInfo'
 import { updateScript } from './utils/scriptRepository'
@@ -130,7 +130,7 @@ export default function App({ onSignOut }) {
       <div className="main-content">
         <ModeCarousel currentMode={mode} onModeChange={setMode} />
         <h1 className="page-title">{pageTitle}</h1>
-        {editor && <Editor editor={editor} mode={mode} />}
+        {editor && <ScriptEditor editor={editor} mode={mode} />}
         {isSaving && <span className="save-indicator"> saving...</span>}
       </div>
       <DevInfo

--- a/src/components/ScriptEditor.jsx
+++ b/src/components/ScriptEditor.jsx
@@ -3,10 +3,10 @@ import { BubbleMenu } from '@tiptap/react/menus'
 import { EditorContent } from '@tiptap/react'
 import { Button } from './ui/button'
 
-export default function Editor({ editor, mode }) {
+export default function ScriptEditor({ editor, mode }) {
   useEffect(() => {
     if (mode) {
-      console.log(`Editor mode set to: ${mode}`)
+      console.log(`ScriptEditor mode set to: ${mode}`)
     }
   }, [mode])
 

--- a/src/index.css
+++ b/src/index.css
@@ -124,7 +124,7 @@ body {
   margin-top: 1rem;
 }
 
-/* Editor */
+/* ScriptEditor */
 .editor-bubble-menu {
   display: flex;
   gap: 0.25rem;

--- a/src/utils/documentScanner.js
+++ b/src/utils/documentScanner.js
@@ -27,7 +27,7 @@ export function scanDocument(doc) {
 }
 
 /**
- * Recalculate numbering for all page and panel headers in the editor.
+ * Recalculate numbering for all page and panel headers in the ScriptEditor.
  * Should be called after insert/delete operations.
  * @param {import('@tiptap/core').Editor} editor
  */


### PR DESCRIPTION
## Summary
- rename Editor component to ScriptEditor and update usage
- refresh docs and comments to reflect ScriptEditor name

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689162eb2ed48321bd0ee47fd0e3ad04