### PR TITLE
feat: allow deleting pages

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -25,6 +25,10 @@ body {
   text-align: center;
   font-size: 1.5rem;
   font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
 }
 
 .save-indicator {
@@ -86,6 +90,12 @@ body {
 
 .page-item.active {
   background: #27272a;
+}
+
+.page-item-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }
 
 .section-heading {

--- a/src/utils/scriptRepository.js
+++ b/src/utils/scriptRepository.js
@@ -5,6 +5,7 @@ import {
   loadPageContent,
   savePageContent,
   createPage,
+  deletePage,
 } from './pageRepository'
 
 export async function listScripts(projectId) {
@@ -29,4 +30,8 @@ export async function loadScriptContent(name, projectId) {
 
 export async function saveScriptContent(name, pageContent, version, projectId) {
   return savePageContent(name, pageContent, version, projectId)
+}
+
+export async function deleteScript(name, projectId) {
+  return deletePage(name, projectId)
 }


### PR DESCRIPTION
## Summary
- allow deleting page scripts via a new deleteScript helper
- add trash icons next to page titles and page list entries so pages can be removed
- style titles and list items to accommodate inline action icons

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68916ff056b88321803471d3ed872556