### PR TITLE
feat: modernize interface design

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
-      rel="stylesheet"
-    />
+      <link
+        href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Source+Sans+Pro:wght@400;600;700&family=Fira+Code:wght@400;500&display=swap"
+        rel="stylesheet"
+      />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React</title>
   </head>

--- a/src/index.css
+++ b/src/index.css
@@ -1,11 +1,45 @@
-body {
-  background-color: #18181b;
-  color: #f4f4f5;
-  -webkit-font-smoothing: antialiased;
-}
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Source+Sans+Pro:wght@400;600;700&family=Fira+Code:wght@400;500&display=swap');
 
 :root {
+  --font-sans: 'Inter', 'Source Sans Pro', sans-serif;
+  --font-mono: 'Fira Code', 'Source Code Pro', monospace;
+
   --tab-width: 4ch;
+
+  --spacing-container: 1.5rem; /* 24px */
+  --spacing-inner: 0.75rem; /* 12px */
+  --radius: 0.5rem; /* 8px */
+  --transition: 0.2s ease;
+
+  /* light theme */
+  --bg-base: #f9f9fb;
+  --bg-panel: #ffffff;
+  --text-primary: #1a1a1d;
+  --text-muted: #6e6e73;
+  --accent: #2563eb;
+  --border-color: #e4e4e7;
+  --hover-bg: #eff1f5;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg-base: #18181b;
+    --bg-panel: #202022;
+    --text-primary: #f5f5f7;
+    --text-muted: #a1a1aa;
+    --accent: #3b82f6;
+    --border-color: #3f3f46;
+    --hover-bg: #2a2a2d;
+  }
+}
+
+body {
+  margin: 0;
+  background-color: var(--bg-base);
+  color: var(--text-primary);
+  font-family: var(--font-sans);
+  font-weight: 400;
+  -webkit-font-smoothing: antialiased;
 }
 
 /* Layout */
@@ -17,31 +51,27 @@ body {
 .main-content {
   flex: 1;
   overflow: auto;
-  padding: 2rem;
+  padding: var(--spacing-container);
 }
 
 .page-title {
-  margin-bottom: 1rem;
-  text-align: center;
-  font-size: 1.5rem;
+  margin-bottom: var(--spacing-inner);
+  font-size: 1.75rem;
   font-weight: 700;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
+  text-align: left;
 }
 
 .save-indicator {
   font-size: 0.75rem;
-  color: #a1a1aa;
+  color: var(--text-muted);
 }
 
 .version {
   position: fixed;
-  bottom: 1rem;
-  right: 1rem;
+  bottom: var(--spacing-inner);
+  right: var(--spacing-inner);
   font-size: 0.875rem;
-  color: #71717a;
+  color: var(--text-muted);
 }
 
 /* Mode carousel */
@@ -49,47 +79,53 @@ body {
   display: flex;
   gap: 0.5rem;
   overflow-x: auto;
-  margin-bottom: 1rem;
+  margin-bottom: var(--spacing-inner);
 }
 
 /* Sidebar */
 .sidebar {
-  width: 16rem;
-  border-right: 1px solid #27272a;
-  padding: 1rem;
+  width: 15rem;
+  background: var(--bg-panel);
+  border-right: 1px solid var(--border-color);
+  padding: var(--spacing-container);
 }
 
 .sidebar-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  margin-bottom: var(--spacing-inner);
 }
 
 .project-list,
 .page-list {
-  margin-top: 0.5rem;
+  margin-top: var(--spacing-inner);
   list-style: none;
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.5rem;
 }
 
 .project-item,
 .page-item {
   cursor: pointer;
-  border-radius: 0.375rem;
-  padding: 0.5rem;
+  border-radius: var(--radius);
+  padding: var(--spacing-inner);
   font-size: 0.875rem;
+  border: 1px solid var(--border-color);
+  transition: background-color var(--transition), border-color var(--transition), box-shadow var(--transition);
 }
 
 .project-item:hover,
 .page-item:hover {
-  background: #27272a;
+  background: var(--hover-bg);
 }
 
 .page-item.active {
-  background: #27272a;
+  border-color: var(--accent);
+  background: var(--accent);
+  color: #fff;
 }
 
 .page-item-header,
@@ -100,22 +136,22 @@ body {
 }
 
 .section-heading {
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--spacing-inner);
   font-size: 0.875rem;
   font-weight: 600;
 }
 
 .empty-message {
   font-size: 0.875rem;
-  color: #a1a1aa;
+  color: var(--text-muted);
 }
 
 .new-page-button {
-  margin-top: 0.5rem;
+  margin-top: var(--spacing-inner);
 }
 
 .signout-container {
-  margin-top: 1rem;
+  margin-top: var(--spacing-container);
 }
 
 .font-medium {
@@ -128,28 +164,28 @@ body {
 
 .page-preview {
   font-size: 0.75rem;
-  color: #a1a1aa;
+  color: var(--text-muted);
 }
 
 .page-navigator {
-  margin-top: 1rem;
+  margin-top: var(--spacing-container);
 }
 
 /* ScriptEditor */
 .editor-bubble-menu {
   display: flex;
   gap: 0.25rem;
-  border: 1px solid #3f3f46;
-  background: #18181b;
+  border: 1px solid var(--border-color);
+  background: var(--bg-panel);
   padding: 0.25rem;
-  border-radius: 0.375rem;
+  border-radius: var(--radius);
 }
 
 .editor-content {
   height: 90vh;
   aspect-ratio: 8.5 / 11;
   width: calc(90vh * 8.5 / 11);
-  background: #27272a;
+  background: var(--bg-panel);
   margin: 0 auto;
   padding: 1in;
   overflow: auto;
@@ -172,28 +208,39 @@ body {
   text-align: center;
   font-size: 1.5rem;
   font-weight: 700;
-  margin-bottom: 1rem;
+  margin-bottom: var(--spacing-inner);
 }
 
 .login-form {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: var(--spacing-inner);
 }
 
 .input {
   width: 100%;
-  background: #27272a;
-  color: #f4f4f5;
-  padding: 0.5rem;
-  border-radius: 0.375rem;
-  border: none;
+  background: var(--bg-panel);
+  color: var(--text-primary);
+  padding: var(--spacing-inner);
+  border-radius: var(--radius);
+  border: 1px solid var(--border-color);
+  transition: border-color var(--transition), box-shadow var(--transition);
+}
+
+.input:hover {
+  border-color: var(--accent);
+}
+
+.input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent);
 }
 
 .error {
   font-size: 0.875rem;
   color: #ef4444;
-  margin-top: 0.5rem;
+  margin-top: var(--spacing-inner);
 }
 
 .full-width {
@@ -201,27 +248,45 @@ body {
 }
 
 /* Buttons */
+
 .btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border: none;
-  border-radius: 0.375rem;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius);
   font-size: 0.875rem;
   font-weight: 500;
   cursor: pointer;
-  transition: background-color 0.2s ease;
+  background: var(--bg-panel);
+  color: var(--text-primary);
+  transition: background-color var(--transition), border-color var(--transition), box-shadow var(--transition), transform var(--transition);
   padding: 0.5rem 1rem;
   white-space: nowrap;
 }
 
+.btn:hover {
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+  transform: translateY(-1px);
+}
+
+.btn:active {
+  transform: translateY(0);
+}
+
+.btn:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--accent);
+}
+
 .btn-default {
-  background: #27272a;
-  color: #f4f4f5;
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
 }
 
 .btn-default:hover {
-  background: #3f3f46;
+  filter: brightness(1.05);
 }
 
 .btn-ghost {
@@ -229,7 +294,7 @@ body {
 }
 
 .btn-ghost:hover {
-  background: #27272a;
+  background: var(--hover-bg);
 }
 
 .btn-sm {
@@ -244,7 +309,7 @@ body {
 
 /* Existing custom node styles */
 .panel-header {
-  font-family: 'Baskerville', serif;
+  font-family: var(--font-sans);
   font-weight: 700;
   font-size: 14pt;
   text-transform: uppercase;
@@ -253,7 +318,7 @@ body {
 }
 
 .character {
-  font-family: 'Courier New', monospace;
+  font-family: var(--font-mono);
   font-weight: 700;
   font-size: 12pt;
   text-transform: uppercase;
@@ -262,7 +327,7 @@ body {
 }
 
 .dialogue {
-  font-family: 'Courier New', monospace;
+  font-family: var(--font-mono);
   font-weight: 400;
   font-size: 12pt;
   margin-left: calc(2 * var(--tab-width));
@@ -270,7 +335,7 @@ body {
 }
 
 .cue-label {
-  font-family: 'Courier New', monospace;
+  font-family: var(--font-mono);
   font-weight: 700;
   font-size: 12pt;
   text-transform: uppercase;
@@ -279,7 +344,7 @@ body {
 }
 
 .cue-content {
-  font-family: 'Courier New', monospace;
+  font-family: var(--font-mono);
   font-weight: 400;
   font-size: 12pt;
   margin-left: calc(2 * var(--tab-width));
@@ -287,7 +352,7 @@ body {
 }
 
 .sfx {
-  font-family: 'Courier New', monospace;
+  font-family: var(--font-mono);
   font-style: italic;
   font-size: 12pt;
   margin-left: calc(2 * var(--tab-width));
@@ -295,10 +360,10 @@ body {
 }
 
 .notes {
-  font-family: 'Courier New', monospace;
+  font-family: var(--font-mono);
   font-style: italic;
   font-size: 12pt;
-  color: #888888;
+  color: var(--text-muted);
   margin-left: calc(1 * var(--tab-width));
   margin-bottom: 8px;
 }
@@ -307,20 +372,21 @@ body {
   position: fixed;
   bottom: 1rem;
   left: 1rem;
-  background: #27272a;
-  padding: 0.5rem;
+  background: var(--bg-panel);
+  padding: var(--spacing-inner);
   font-size: 0.75rem;
-  color: #a1a1aa;
-  border-radius: 0.375rem;
+  color: var(--text-muted);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius);
 }
 
 .dev-log {
-  margin-top: 0.5rem;
-  border-top: 1px solid #52525b;
-  padding-top: 0.5rem;
+  margin-top: var(--spacing-inner);
+  border-top: 1px solid var(--border-color);
+  padding-top: var(--spacing-inner);
   max-height: 8rem;
   overflow-y: auto;
-  font-family: 'Courier New', monospace;
+  font-family: var(--font-mono);
 }
 
 .dev-log-entry {


### PR DESCRIPTION
## Summary
- Introduce light and dark theme variables with Inter/Source Sans and Fira Code typography
- Refresh layout spacing and sidebar/content hierarchy for cleaner presentation
- Standardize inputs and buttons with rounded corners, hover transitions, and accent active states

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6896bd26b2c08321af6d4d2226a0d423