### PR TITLE
Add configurable settings sidebar

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,6 +20,7 @@ import Sidebar from './components/Sidebar'
 import ScriptEditor from './components/ScriptEditor'
 import ModeCarousel from './components/ModeCarousel'
 import DevInfo from './components/DevInfo'
+import SettingsSidebar from './components/SettingsSidebar'
 import { updateScript, deleteScript } from './utils/scriptRepository'
 import { Button } from './components/ui/button'
 
@@ -33,6 +34,10 @@ export default function App({ onSignOut }) {
   const [totalPages, setTotalPages] = useState(0)
   const [wordCount, setWordCount] = useState(0)
   const sidebarRef = useRef(null)
+  const [settingsOpen, setSettingsOpen] = useState(false)
+  const [theme, setTheme] = useState('light')
+  const [accentColor, setAccentColor] = useState('#2563eb')
+  const [showDevInfo, setShowDevInfo] = useState(false)
   const editor = useEditor({
     extensions: [
       StarterKit,
@@ -51,6 +56,14 @@ export default function App({ onSignOut }) {
     ],
     content: pageContent,
   })
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme)
+  }, [theme])
+
+  useEffect(() => {
+    document.documentElement.style.setProperty('--accent', accentColor)
+  }, [accentColor])
 
   function handleSelectProject(name, data) {
     setActiveProject(data)
@@ -185,14 +198,35 @@ export default function App({ onSignOut }) {
         {editor && <ScriptEditor editor={editor} mode={mode} />}
         {isSaving && <span className="save-indicator"> saving...</span>}
       </div>
-      <DevInfo
-        projectName={activeProject?.name}
-        currentPage={pageTitle}
-        totalPages={totalPages}
-        wordCount={wordCount}
-        logs={devLogs}
-      />
+      {showDevInfo && (
+        <DevInfo
+          projectName={activeProject?.name}
+          currentPage={pageTitle}
+          totalPages={totalPages}
+          wordCount={wordCount}
+          logs={devLogs}
+        />
+      )}
       <div className="version">Panelist v{__APP_VERSION__}</div>
+      <Button
+        size="sm"
+        variant="ghost"
+        className="settings-button"
+        onClick={() => setSettingsOpen(true)}
+      >
+        ⚙️
+      </Button>
+      <SettingsSidebar
+        open={settingsOpen}
+        onClose={() => setSettingsOpen(false)}
+        theme={theme}
+        setTheme={setTheme}
+        accentColor={accentColor}
+        setAccentColor={setAccentColor}
+        onSignOut={onSignOut}
+        showDevInfo={showDevInfo}
+        setShowDevInfo={setShowDevInfo}
+      />
     </div>
   )
 }

--- a/src/components/SettingsSidebar.jsx
+++ b/src/components/SettingsSidebar.jsx
@@ -1,0 +1,73 @@
+import { Button } from './ui/button'
+import { cn } from '../lib/utils'
+import { signOut } from '../utils/auth.js'
+
+export default function SettingsSidebar({
+  open,
+  onClose,
+  theme,
+  setTheme,
+  accentColor,
+  setAccentColor,
+  onSignOut,
+  showDevInfo,
+  setShowDevInfo,
+}) {
+  async function handleSignOut() {
+    try {
+      await signOut()
+      onSignOut?.()
+    } catch (err) {
+      console.error('signOut failed:', err.message)
+    }
+  }
+
+  return (
+    <aside className={cn('settings-sidebar', open && 'open')}>
+      <div className="settings-header">
+        <div className="font-semibold">Settings</div>
+        <Button size="sm" variant="ghost" onClick={onClose}>
+          ✖️
+        </Button>
+      </div>
+      <div>
+        <h4 className="section-heading">Display</h4>
+        <div className="setting-item">
+          <label>
+            Theme
+            <select value={theme} onChange={(e) => setTheme(e.target.value)}>
+              <option value="light">Light</option>
+              <option value="dark">Dark</option>
+            </select>
+          </label>
+        </div>
+        <div className="setting-item">
+          <label>
+            Accent Color
+            <input
+              type="color"
+              value={accentColor}
+              onChange={(e) => setAccentColor(e.target.value)}
+            />
+          </label>
+        </div>
+      </div>
+      <div className="settings-section">
+        <h4 className="section-heading">Account</h4>
+        <Button variant="ghost" className="full-width" onClick={handleSignOut}>
+          Sign out
+        </Button>
+      </div>
+      <div className="settings-section">
+        <h4 className="section-heading">Developer</h4>
+        <Button
+          variant="ghost"
+          className="full-width"
+          onClick={() => setShowDevInfo(!showDevInfo)}
+        >
+          {showDevInfo ? 'Hide Dev Window' : 'Show Dev Window'}
+        </Button>
+      </div>
+    </aside>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -21,6 +21,16 @@
   --hover-bg: #eff1f5;
 }
 
+:root[data-theme='dark'] {
+  --bg-base: #18181b;
+  --bg-panel: #202022;
+  --text-primary: #f5f5f7;
+  --text-muted: #a1a1aa;
+  --accent: #3b82f6;
+  --border-color: #3f3f46;
+  --hover-bg: #2a2a2d;
+}
+
 @media (prefers-color-scheme: dark) {
   :root {
     --bg-base: #18181b;
@@ -88,6 +98,49 @@ body {
   background: var(--bg-panel);
   border-right: 1px solid var(--border-color);
   padding: var(--spacing-container);
+}
+
+.settings-sidebar {
+  position: fixed;
+  top: 0;
+  right: 0;
+  height: 100%;
+  width: 15rem;
+  background: var(--bg-panel);
+  border-left: 1px solid var(--border-color);
+  padding: var(--spacing-container);
+  transform: translateX(100%);
+  transition: transform var(--transition);
+}
+
+.settings-sidebar.open {
+  transform: translateX(0);
+}
+
+.settings-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--spacing-inner);
+}
+
+.settings-button {
+  position: fixed;
+  top: var(--spacing-inner);
+  right: var(--spacing-inner);
+  z-index: 50;
+}
+
+.settings-section {
+  margin-top: var(--spacing-container);
+}
+
+.setting-item {
+  margin-bottom: var(--spacing-inner);
+  font-size: 0.875rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
 }
 
 .sidebar-header {


### PR DESCRIPTION
## Summary
- Add gear-activated settings sidebar for display, account, and developer options
- Support light/dark themes and customizable accent color
- Allow toggling dev info window and signing out from settings menu

## Testing
- `npm test` *(fails: Missing script "test"`)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896c1800c6083219e0ec8567b094808