### PR TITLE
Define light and dark theme variables

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,7 +20,7 @@ import Sidebar from './components/Sidebar'
 import ScriptEditor from './components/ScriptEditor'
 import ModeCarousel from './components/ModeCarousel'
 import DevInfo from './components/DevInfo'
-import { listScripts, readScript, updateScript, createScript, deleteScript } from './utils/scriptRepository'
+import { listScripts, readScript, updateScript, createScript } from './utils/scriptRepository'
 import { scanDocument, recalcNumbering } from './utils/documentScanner'
 import SettingsSidebar from './components/SettingsSidebar'
 import { Button } from './components/ui/button'
@@ -57,6 +57,9 @@ export default function App({ onSignOut }) {
     ],
     content: '',
   })
+
+  const pageTitle = pages[activePage] ?? ''
+  const totalPages = pages.length
 
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', theme)

--- a/src/index.css
+++ b/src/index.css
@@ -10,8 +10,11 @@
   --spacing-inner: 0.75rem; /* 12px */
   --radius: 0.5rem; /* 8px */
   --transition: 0.2s ease;
+}
 
-  /* light theme */
+
+/* Light theme */
+:root[data-theme='light'] {
   --bg-base: #f9f9fb;
   --bg-panel: #ffffff;
   --text-primary: #1a1a1d;
@@ -21,6 +24,7 @@
   --hover-bg: #eff1f5;
 }
 
+/* Dark theme */
 :root[data-theme='dark'] {
   --bg-base: #18181b;
   --bg-panel: #202022;
@@ -31,8 +35,9 @@
   --hover-bg: #2a2a2d;
 }
 
+/* Respect user's system preference when no theme is set */
 @media (prefers-color-scheme: dark) {
-  :root {
+  :root:not([data-theme]) {
     --bg-base: #18181b;
     --bg-panel: #202022;
     --text-primary: #f5f5f7;


### PR DESCRIPTION
## Summary
- Define explicit `data-theme` rules for light and dark modes so the theme toggle works regardless of system preference.
- Compute current page title and total pages in `App.jsx` and remove unused imports to satisfy lint.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896c632be0c8321aec96f32eddca79b