### PR TITLE
Move mode selector into sidebar with dial animation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,9 +18,8 @@ import {
 } from './extensions/customNodes'
 import Sidebar from './components/Sidebar'
 import ScriptEditor from './components/ScriptEditor'
-import ModeCarousel from './components/ModeCarousel'
 import DevInfo from './components/DevInfo'
-import { listScripts, readScript, updateScript, createScript, deleteScript } from './utils/scriptRepository'
+import { listScripts, readScript, updateScript, createScript } from './utils/scriptRepository'
 import { scanDocument, recalcNumbering } from './utils/documentScanner'
 import SettingsSidebar from './components/SettingsSidebar'
 import { Button } from './components/ui/button'
@@ -29,7 +28,7 @@ export default function App({ onSignOut }) {
   const [activeProject, setActiveProject] = useState(null)
   const [isSaving, setIsSaving] = useState(false)
   const [devLogs, setDevLogs] = useState([])
-  const [mode, setMode] = useState('Write')
+  const [mode, setMode] = useState('Script')
   const [pages, setPages] = useState([])
   const [activePage, setActivePage] = useState(0)
   const [wordCount, setWordCount] = useState(0)
@@ -232,6 +231,9 @@ export default function App({ onSignOut }) {
     }
   }
 
+  const pageTitle = pages[activePage] || ''
+  const totalPages = pages.length
+
   return (
     <div className="app-layout">
       <Sidebar
@@ -241,9 +243,10 @@ export default function App({ onSignOut }) {
         onSelectProject={handleSelectProject}
         onSelectPage={handleNavigatePage}
         onSignOut={onSignOut}
+        currentMode={mode}
+        onModeChange={setMode}
       />
       <div className="main-content">
-        <ModeCarousel currentMode={mode} onModeChange={setMode} />
         {editor && <ScriptEditor editor={editor} mode={mode} />}
         {isSaving && <span className="save-indicator"> saving...</span>}
       </div>

--- a/src/components/ModeCarousel.jsx
+++ b/src/components/ModeCarousel.jsx
@@ -1,35 +1,32 @@
-import { useRef } from 'react'
 import { Button } from './ui/button'
 
-const modes = ['Script', 'Tiles*', 'Animation*']
+const modes = ['Script', 'Storyboards', 'Inks', 'Colors', 'Final']
 
 export default function ModeCarousel({ currentMode, onModeChange }) {
-  const containerRef = useRef(null)
-
-  function handleSelect(mode) {
-    const isPlaceholder = mode.endsWith('*')
-    const cleanMode = mode.replace('*', '')
-    if (isPlaceholder) {
-      console.log(`${cleanMode} mode is coming soon`)
-      return
-    }
-    onModeChange?.(cleanMode)
-  }
+  const index = modes.indexOf(currentMode)
+  const prev = modes[(index - 1 + modes.length) % modes.length]
+  const next = modes[(index + 1) % modes.length]
 
   return (
-    <div className="mode-carousel" ref={containerRef}>
+    <div className="mode-carousel">
       {modes.map((mode) => {
-        const cleanMode = mode.replace('*', '')
-        const isActive = currentMode === cleanMode
-          return (
-            <Button
-              key={mode}
-              variant={isActive ? 'default' : 'ghost'}
-              onClick={() => handleSelect(mode)}
-            >
-              {mode}
-            </Button>
-          )
+        let position = 'hidden'
+        if (mode === currentMode) position = 'active'
+        else if (mode === prev) position = 'prev'
+        else if (mode === next) position = 'next'
+        return (
+          <Button
+            key={mode}
+            variant="ghost"
+            className={`mode-button ${position}`}
+            onClick={() => {
+              if (mode === prev) onModeChange?.(prev)
+              else if (mode === next) onModeChange?.(next)
+            }}
+          >
+            {mode}
+          </Button>
+        )
       })}
     </div>
   )

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -13,6 +13,7 @@ import {
 import { signOut } from '../utils/auth.js'
 import { Button } from './ui/button'
 import { cn } from '../lib/utils'
+import ModeCarousel from './ModeCarousel'
 
 function PageNavigator({ pages = [], activePage = 0, onSelectPage }) {
   return (
@@ -37,7 +38,15 @@ function PageNavigator({ pages = [], activePage = 0, onSelectPage }) {
 }
 
 const Sidebar = forwardRef(function Sidebar(
-  { pages = [], activePage = 0, onSelectPage, onSelectProject, onSignOut },
+  {
+    pages = [],
+    activePage = 0,
+    onSelectPage,
+    onSelectProject,
+    onSignOut,
+    currentMode,
+    onModeChange,
+  },
   ref,
 ) {
   const [projects, setProjects] = useState([])
@@ -194,6 +203,8 @@ const Sidebar = forwardRef(function Sidebar(
       {selectedProject && (
         <PageNavigator pages={pages} activePage={activePage} onSelectPage={onSelectPage} />
       )}
+
+      <ModeCarousel currentMode={currentMode} onModeChange={onModeChange} />
 
       <div className="signout-container">
         <Button variant="ghost" className="full-width" onClick={handleSignOut}>

--- a/src/index.css
+++ b/src/index.css
@@ -86,10 +86,40 @@ body {
 
 /* Mode carousel */
 .mode-carousel {
-  display: flex;
-  gap: 0.5rem;
-  overflow-x: auto;
-  margin-bottom: var(--spacing-inner);
+  position: relative;
+  height: 2.5rem;
+  margin-top: var(--spacing-container);
+}
+
+.mode-carousel .mode-button {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  transition: transform var(--transition) ease, filter var(--transition) ease,
+    opacity var(--transition) ease;
+}
+
+.mode-carousel .mode-button.active {
+  z-index: 2;
+  transform: translateX(-50%) scale(1.1);
+}
+
+.mode-carousel .mode-button.prev {
+  transform: translateX(-150%) scale(0.9);
+  filter: blur(1px);
+  opacity: 0.6;
+}
+
+.mode-carousel .mode-button.next {
+  transform: translateX(50%) scale(0.9);
+  filter: blur(1px);
+  opacity: 0.6;
+}
+
+.mode-carousel .mode-button.hidden {
+  opacity: 0;
+  pointer-events: none;
 }
 
 /* Sidebar */


### PR DESCRIPTION
## Summary
- relocate mode selection carousel into the sidebar below the page navigator
- add dial-style ModeCarousel supporting Script, Storyboards, Inks, Colors, and Final modes
- style carousel so active mode is centered while adjacent modes blur to left/right; others remain hidden

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896c6fa47488321b53c9a7efde8653e