### PR TITLE
Toggle settings panel with gear icon

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,7 +20,7 @@ import Sidebar from './components/Sidebar'
 import ScriptEditor from './components/ScriptEditor'
 import ModeCarousel from './components/ModeCarousel'
 import DevInfo from './components/DevInfo'
-import { listScripts, readScript, updateScript, createScript, deleteScript } from './utils/scriptRepository'
+import { listScripts, readScript, updateScript, createScript } from './utils/scriptRepository'
 import { scanDocument, recalcNumbering } from './utils/documentScanner'
 import SettingsSidebar from './components/SettingsSidebar'
 import { Button } from './components/ui/button'
@@ -232,6 +232,9 @@ export default function App({ onSignOut }) {
     }
   }
 
+  const pageTitle = pages[activePage]
+  const totalPages = pages.length
+
   return (
     <div className="app-layout">
       <Sidebar
@@ -261,13 +264,12 @@ export default function App({ onSignOut }) {
         size="sm"
         variant="ghost"
         className="settings-button"
-        onClick={() => setSettingsOpen(true)}
+        onClick={() => setSettingsOpen((open) => !open)}
       >
         ⚙️
       </Button>
       <SettingsSidebar
         open={settingsOpen}
-        onClose={() => setSettingsOpen(false)}
         theme={theme}
         setTheme={setTheme}
         accentColor={accentColor}

--- a/src/components/SettingsSidebar.jsx
+++ b/src/components/SettingsSidebar.jsx
@@ -4,7 +4,6 @@ import { signOut } from '../utils/auth.js'
 
 export default function SettingsSidebar({
   open,
-  onClose,
   theme,
   setTheme,
   accentColor,
@@ -26,9 +25,6 @@ export default function SettingsSidebar({
     <aside className={cn('settings-sidebar', open && 'open')}>
       <div className="settings-header">
         <div className="font-semibold">Settings</div>
-        <Button size="sm" variant="ghost" onClick={onClose}>
-          ✖️
-        </Button>
       </div>
       <div>
         <h4 className="section-heading">Display</h4>


### PR DESCRIPTION
## Summary
- Allow the gear button to both open and close the settings sidebar
- Remove redundant close button from the settings panel header
- Define page title and total page count for developer info

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896c7226abc83218229edc6a64abced