### PR TITLE
Restore page navigator and project display

### DIFF
--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -51,6 +51,7 @@ const Sidebar = forwardRef(function Sidebar(
 ) {
   const [projects, setProjects] = useState([])
   const [selectedProject, setSelectedProject] = useState(null)
+  const [selectedProjectName, setSelectedProjectName] = useState('')
   const [dropdownOpen, setDropdownOpen] = useState(false)
   const [menuOpen, setMenuOpen] = useState(false)
 
@@ -72,6 +73,7 @@ const Sidebar = forwardRef(function Sidebar(
   const handleSelectProject = React.useCallback(
     async (name) => {
       try {
+        setSelectedProjectName(name)
         const result = await readProject(name)
         const data = result?.data ?? result
         setSelectedProject(data)
@@ -119,18 +121,19 @@ const Sidebar = forwardRef(function Sidebar(
     }
   }
 
-  async function handleDeleteProject(e, name = selectedProject?.name) {
+  async function handleDeleteProject(e, name = selectedProjectName) {
     e?.stopPropagation()
     if (!name) return
     if (!confirm(`Delete project "${name}"?`)) return
     try {
       await deleteProject(name)
       const names = await refreshProjects()
-      if (selectedProject?.name === name) {
+      if (selectedProjectName === name) {
         if (names.length > 0) {
           await handleSelectProject(names[0])
         } else {
           setSelectedProject(null)
+          setSelectedProjectName('')
           onSelectProject?.('', null)
         }
       }
@@ -161,7 +164,7 @@ const Sidebar = forwardRef(function Sidebar(
           style={{ cursor: 'pointer' }}
           onClick={() => setDropdownOpen((o) => !o)}
         >
-          {selectedProject?.name ?? 'Select project'}
+          {selectedProjectName || 'Select project'}
         </div>
         <div style={{ position: 'relative' }}>
           <Button size="sm" variant="ghost" onClick={() => setMenuOpen((o) => !o)}>
@@ -200,9 +203,7 @@ const Sidebar = forwardRef(function Sidebar(
         </ul>
       )}
 
-      {selectedProject && (
-        <PageNavigator pages={pages} activePage={activePage} onSelectPage={onSelectPage} />
-      )}
+      <PageNavigator pages={pages} activePage={activePage} onSelectPage={onSelectPage} />
 
       <ModeCarousel currentMode={currentMode} onModeChange={onModeChange} />
 


### PR DESCRIPTION
## Summary
- Track selected project name separately to keep project header populated
- Always render the page navigator so navigation isn't lost when no project data is loaded
- Reset project state properly when deleting the active project

## Testing
- `npm run lint`
- `npm run build`
- `npm run test:supabase` *(fails: Missing VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_6896cb36c0a48321b853d61f8362b186