### PR TITLE
Remove duplicate sign out button from sidebar

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -242,7 +242,6 @@ export default function App({ onSignOut }) {
         activePage={activePage}
         onSelectProject={handleSelectProject}
         onSelectPage={handleNavigatePage}
-        onSignOut={onSignOut}
         currentMode={mode}
         onModeChange={setMode}
       />

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -10,7 +10,6 @@ import {
   readProject,
   deleteProject,
 } from '../utils/projectRepository'
-import { signOut } from '../utils/auth.js'
 import { Button } from './ui/button'
 import { cn } from '../lib/utils'
 import ModeCarousel from './ModeCarousel'
@@ -43,7 +42,6 @@ const Sidebar = forwardRef(function Sidebar(
     activePage = 0,
     onSelectPage,
     onSelectProject,
-    onSignOut,
     currentMode,
     onModeChange,
   },
@@ -143,16 +141,6 @@ const Sidebar = forwardRef(function Sidebar(
     }
   }
 
-  async function handleSignOut() {
-    try {
-      await signOut()
-      onSignOut?.()
-    } catch (error) {
-      console.error('signOut failed:', error?.message || error)
-      console.warn('Sign out failed')
-    }
-  }
-
   // Expose an imperative handle if the parent wants to programmatically select a page index
   useImperativeHandle(ref, () => ({ selectPage: onSelectPage }), [onSelectPage])
 
@@ -206,12 +194,6 @@ const Sidebar = forwardRef(function Sidebar(
       <PageNavigator pages={pages} activePage={activePage} onSelectPage={onSelectPage} />
 
       <ModeCarousel currentMode={currentMode} onModeChange={onModeChange} />
-
-      <div className="signout-container">
-        <Button variant="ghost" className="full-width" onClick={handleSignOut}>
-          Sign out
-        </Button>
-      </div>
     </aside>
   )
 })

--- a/src/index.css
+++ b/src/index.css
@@ -255,10 +255,6 @@ body {
   margin-top: var(--spacing-inner);
 }
 
-.signout-container {
-  margin-top: var(--spacing-container);
-}
-
 .font-medium {
   font-weight: 500;
 }


### PR DESCRIPTION
## Summary
- remove redundant sign out button from main sidebar
- clean up unused sign-out prop and CSS

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896cd17100483219f6b529eae3ad60f