### PR TITLE
Shift editor left with settings panel

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,6 +23,7 @@ import { listScripts, readScript, updateScript, createScript } from './utils/scr
 import { scanDocument, recalcNumbering } from './utils/documentScanner'
 import SettingsSidebar from './components/SettingsSidebar'
 import { Button } from './components/ui/button'
+import { cn } from './lib/utils'
 
 export default function App({ onSignOut }) {
   const [activeProject, setActiveProject] = useState(null)
@@ -246,7 +247,7 @@ export default function App({ onSignOut }) {
         currentMode={mode}
         onModeChange={setMode}
       />
-      <div className="main-content">
+      <div className={cn('main-content', settingsOpen && 'shifted')}>
         {editor && <ScriptEditor editor={editor} mode={mode} />}
         {isSaving && <span className="save-indicator"> saving...</span>}
       </div>

--- a/src/index.css
+++ b/src/index.css
@@ -67,6 +67,11 @@ body {
   flex: 1;
   overflow: auto;
   padding: var(--spacing-container);
+  transition: transform var(--transition);
+}
+
+.main-content.shifted {
+  transform: translateX(-15rem);
 }
 
 .page-title {


### PR DESCRIPTION
## Summary
- Smoothly slide the script editor left when the settings sidebar opens
- Add CSS transition for main content shifting

## Testing
- `npm run lint`
- `npm run test:supabase` *(fails: Missing VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_6896cd47c8dc8321879ee8b06c2563b7