### PR TITLE
Prevent editor overlapping left sidebar

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -67,11 +67,17 @@ body {
   flex: 1;
   overflow: auto;
   padding: var(--spacing-container);
-  transition: transform var(--transition);
+  transition: margin-right var(--transition);
 }
 
 .main-content.shifted {
-  transform: translateX(-15rem);
+  margin-right: 15rem;
+}
+
+@media (max-width: 60rem) {
+  .main-content.shifted {
+    margin-right: 0;
+  }
 }
 
 .page-title {


### PR DESCRIPTION
## Summary
- Ensure main content stays clear of the left sidebar by replacing the transform shift with a right margin
- Add responsive behavior so settings panel overlays content on narrow screens

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896cf19d61c8321875d972b84f9ef94