### PR TITLE
feat: enable multi-page scrolling editor

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -300,7 +300,7 @@ body {
   background: var(--bg-panel);
   margin: 0 auto;
   padding: 1in;
-  overflow: auto;
+  overflow: hidden;
   border-radius: 0;
   box-shadow: 0 0 15px rgba(0, 0, 0, 0.4);
 }
@@ -308,6 +308,10 @@ body {
 .editor-content .ProseMirror {
   min-height: 100%;
   height: 100%;
+}
+
+.page-wrapper {
+  margin-bottom: var(--spacing-container);
 }
 
 /* Login */


### PR DESCRIPTION
## Summary
- display all script pages in a vertical scrollable stack
- track and save active page based on viewport visibility
- clean up editor styles for multi-page layout

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68979b7a825c8321a290120e808659c1