### PR TITLE
fix: keep settings sidebar visible

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -150,7 +150,8 @@ body {
   position: fixed;
   top: 0;
   right: 0;
-  height: 100%;
+  height: 100vh;
+  overflow-y: auto;
   width: 15rem;
   background: var(--bg-panel);
   border-left: 1px solid var(--border-color);


### PR DESCRIPTION
## Summary
- ensure settings sidebar stays visible and scrollable while page scrolls

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68979e0f70688321a4c9ed2df9893a7c