### PR TITLE
chore: add auth debug logging

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -11,21 +11,29 @@ function Root() {
 
   useEffect(() => {
     supabase.auth.getSession().then(({ data }) => {
+      console.log('Initial auth session:', data.session)
       setSession(data.session)
     })
     const {
       data: { subscription },
-    } = supabase.auth.onAuthStateChange((_event, session) => {
+    } = supabase.auth.onAuthStateChange((event, session) => {
+      console.log('Auth state changed:', event, session)
       setSession(session)
     })
     return () => subscription.unsubscribe()
   }, [])
 
   if (!session) {
-    return <Login onLogin={setSession} />
+    return <Login onLogin={(s) => {
+      console.log('Login successful, session set')
+      setSession(s)
+    }} />
   }
 
-  return <App onSignOut={() => setSession(null)} />
+  return <App onSignOut={() => {
+    console.log('User signed out from App')
+    setSession(null)
+  }} />
 }
 
 export default Root

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -2,9 +2,12 @@ import { supabase } from './supabaseClient.js'
 
 export async function signUp(email, password) {
   try {
+    console.log('Attempting signUp for', email)
     const result = await supabase.auth.signUp({ email, password })
     if (result.error) {
       console.error('signUp error:', result.error)
+    } else {
+      console.log('signUp success for user', result.data.user?.id)
     }
     return result
   } catch (error) {
@@ -15,9 +18,12 @@ export async function signUp(email, password) {
 
 export async function signIn(email, password) {
   try {
+    console.log('Attempting signIn for', email)
     const result = await supabase.auth.signInWithPassword({ email, password })
     if (result.error) {
       console.error('signIn error:', result.error)
+    } else {
+      console.log('signIn success for user', result.data.user?.id)
     }
     return result
   } catch (error) {
@@ -28,9 +34,12 @@ export async function signIn(email, password) {
 
 export async function signOut() {
   try {
+    console.log('Signing out current user')
     const result = await supabase.auth.signOut()
     if (result.error) {
       console.error('signOut error:', result.error)
+    } else {
+      console.log('signOut success')
     }
     return result
   } catch (error) {

--- a/src/utils/supabaseClient.js
+++ b/src/utils/supabaseClient.js
@@ -3,14 +3,29 @@ import { createClient } from '@supabase/supabase-js'
 const url = import.meta.env.VITE_SUPABASE_URL
 const key = import.meta.env.VITE_SUPABASE_ANON_KEY
 
+if (!url) {
+  console.warn('VITE_SUPABASE_URL is not defined')
+}
+if (!key) {
+  console.warn('VITE_SUPABASE_ANON_KEY is not defined')
+}
+
 export const supabase = createClient(url, key)
 
 export async function getSupabase() {
+  console.log('Fetching current Supabase session')
   const {
     data: { session },
     error,
   } = await supabase.auth.getSession()
-  if (error) throw error
-  if (!session) throw new Error('User is not logged in')
+  if (error) {
+    console.error('Error retrieving session:', error)
+    throw error
+  }
+  if (!session) {
+    console.warn('No active session found')
+    throw new Error('User is not logged in')
+  }
+  console.log('Supabase session found for user', session.user?.id)
   return supabase
 }


### PR DESCRIPTION
## Summary
- warn if Supabase environment variables are missing
- add console logs for sign up/in/out actions and session fetches
- log auth state changes and user sign outs in the app entry

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897a5c4936083218ca90de346fabf87