### PR TITLE
feat: add zoom controls to script editor

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,9 @@ import SettingsSidebar from './components/SettingsSidebar'
 import { Button } from './components/ui/button'
 import { cn } from './lib/utils'
 
+const PAGE_WIDTH = 816
+const PAGE_HEIGHT = 1056
+
 export default function App({ onSignOut }) {
   const [activeProject, setActiveProject] = useState(null)
   const [isSaving, setIsSaving] = useState(false)
@@ -26,6 +29,7 @@ export default function App({ onSignOut }) {
   const [showDevInfo, setShowDevInfo] = useState(false)
   const pageRefs = useRef([])
   const saveTimeoutsRef = useRef({})
+  const [zoom, setZoom] = useState(1)
 
   const pageTitle = pages[activePage] ?? ''
   const totalPages = pages.length
@@ -41,6 +45,25 @@ export default function App({ onSignOut }) {
   useEffect(() => {
     document.documentElement.style.setProperty('--accent', accentColor)
   }, [accentColor])
+
+  useEffect(() => {
+    function updateZoom() {
+      const widthScale = (window.innerWidth - 32) / PAGE_WIDTH
+      const heightScale = (window.innerHeight - 32) / PAGE_HEIGHT
+      setZoom(Math.min(widthScale, heightScale))
+    }
+    updateZoom()
+    window.addEventListener('resize', updateZoom)
+    return () => window.removeEventListener('resize', updateZoom)
+  }, [])
+
+  function handleZoomIn() {
+    setZoom(z => z * 1.1)
+  }
+
+  function handleZoomOut() {
+    setZoom(z => z / 1.1)
+  }
 
   function handleSelectProject(name, data) {
     setActiveProject(data)
@@ -179,6 +202,7 @@ export default function App({ onSignOut }) {
             onUpdate={handlePageUpdate}
             onInView={handlePageInView}
             characters={activeProject?.characters ?? []}
+            zoom={zoom}
           />
         ))}
         {isSaving && <span className="save-indicator"> saving...</span>}
@@ -192,6 +216,15 @@ export default function App({ onSignOut }) {
           logs={devLogs}
         />
       )}
+      <div className="zoom-controls">
+        <Button size="sm" variant="ghost" onClick={handleZoomOut}>
+          -
+        </Button>
+        <span>{Math.round(zoom * 100)}%</span>
+        <Button size="sm" variant="ghost" onClick={handleZoomIn}>
+          +
+        </Button>
+      </div>
       <div className="version">Panelist v{__APP_VERSION__}</div>
       <Button
         size="sm"

--- a/src/components/ScriptEditor.jsx
+++ b/src/components/ScriptEditor.jsx
@@ -19,8 +19,19 @@ import {
 import { Button } from './ui/button'
 import { recalcNumbering } from '../utils/documentScanner'
 
+const PAGE_WIDTH = 816
+const PAGE_HEIGHT = 1056
+
 const ScriptEditor = forwardRef(function ScriptEditor(
-  { content, mode, pageIndex, onUpdate, onInView, characters = [] },
+  {
+    content,
+    mode,
+    pageIndex,
+    onUpdate,
+    onInView,
+    characters = [],
+    zoom = 1,
+  },
   ref,
 ) {
   const containerRef = useRef(null)
@@ -81,31 +92,44 @@ const ScriptEditor = forwardRef(function ScriptEditor(
   if (!editor) return null
 
   return (
-    <div ref={containerRef} className="page-wrapper">
-      <BubbleMenu className="editor-bubble-menu" editor={editor}>
-        <Button
-          size="sm"
-          variant={editor.isActive('bold') ? 'default' : 'ghost'}
-          onClick={() => editor.chain().focus().toggleBold().run()}
-        >
-          B
-        </Button>
-        <Button
-          size="sm"
-          variant={editor.isActive('italic') ? 'default' : 'ghost'}
-          onClick={() => editor.chain().focus().toggleItalic().run()}
-        >
-          I
-        </Button>
-        <Button
-          size="sm"
-          variant={editor.isActive('underline') ? 'default' : 'ghost'}
-          onClick={() => editor.chain().focus().toggleUnderline().run()}
-        >
-          U
-        </Button>
-      </BubbleMenu>
-      <EditorContent editor={editor} className="editor-content" />
+    <div
+      ref={containerRef}
+      className="page-wrapper"
+      style={{ width: PAGE_WIDTH * zoom, height: PAGE_HEIGHT * zoom }}
+    >
+      <div
+        style={{
+          width: PAGE_WIDTH,
+          height: PAGE_HEIGHT,
+          transform: `scale(${zoom})`,
+          transformOrigin: 'top left',
+        }}
+      >
+        <BubbleMenu className="editor-bubble-menu" editor={editor}>
+          <Button
+            size="sm"
+            variant={editor.isActive('bold') ? 'default' : 'ghost'}
+            onClick={() => editor.chain().focus().toggleBold().run()}
+          >
+            B
+          </Button>
+          <Button
+            size="sm"
+            variant={editor.isActive('italic') ? 'default' : 'ghost'}
+            onClick={() => editor.chain().focus().toggleItalic().run()}
+          >
+            I
+          </Button>
+          <Button
+            size="sm"
+            variant={editor.isActive('underline') ? 'default' : 'ghost'}
+            onClick={() => editor.chain().focus().toggleUnderline().run()}
+          >
+            U
+          </Button>
+        </BubbleMenu>
+        <EditorContent editor={editor} className="editor-content" />
+      </div>
     </div>
   )
 })

--- a/src/index.css
+++ b/src/index.css
@@ -311,11 +311,11 @@ body {
 }
 
 .editor-content {
-  height: 90vh;
-  aspect-ratio: 8.5 / 11;
-  width: calc(90vh * 8.5 / 11);
+  box-sizing: border-box;
+  width: 100%;
+  height: 100%;
   background: var(--bg-panel);
-  margin: 0 auto;
+  margin: 0;
   padding: 1in;
   overflow: hidden;
   border-radius: 0;
@@ -328,7 +328,7 @@ body {
 }
 
 .page-wrapper {
-  margin-bottom: var(--spacing-container);
+  margin: 0 auto var(--spacing-container);
 }
 
 /* Login */
@@ -524,4 +524,17 @@ body {
 
 .dev-log-entry {
   margin-bottom: 0.25rem;
+}
+
+.zoom-controls {
+  position: fixed;
+  bottom: var(--spacing-inner);
+  left: var(--spacing-inner);
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  background: var(--bg-panel);
+  border: 1px solid var(--border-color);
+  padding: 0.25rem 0.5rem;
+  border-radius: var(--radius);
 }


### PR DESCRIPTION
## Summary
- add zoom state and controls to adjust page scale
- scale ScriptEditor content based on zoom prop
- update styles for scalable page layout and new zoom controls

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897c1ef66c48321ac18fe24dc820eda