### PR TITLE
fix: reuse Supabase session promise

### DIFF
--- a/src/utils/supabaseClient.js
+++ b/src/utils/supabaseClient.js
@@ -14,6 +14,7 @@ export const supabase = createClient(url, key)
 
 // cache the session after first retrieval
 let sessionCache = null
+let sessionPromise = null
 
 export async function getSupabase() {
   if (sessionCache) {
@@ -23,13 +24,18 @@ export async function getSupabase() {
     return supabase
   }
 
-  if (import.meta.env.DEV) {
-    console.debug('Fetching current Supabase session')
+  if (!sessionPromise) {
+    if (import.meta.env.DEV) {
+      console.debug('Fetching current Supabase session')
+    }
+    sessionPromise = supabase.auth.getSession()
   }
+
   const {
     data: { session },
     error,
-  } = await supabase.auth.getSession()
+  } = await sessionPromise
+  sessionPromise = null
   if (error) {
     console.error('Error retrieving session:', error)
     throw error


### PR DESCRIPTION
## Summary
- avoid repeated Supabase `getSession` calls by sharing a module-level promise
- cache resolved session and log fetch only when initiating retrieval

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897cd1444dc8321ace953d8243ff60e