### PR TITLE
feat: cache current user id

### DIFF
--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -1,4 +1,5 @@
 import { supabase } from './supabaseClient.js'
+import { clearCachedUserId } from './authCache.js'
 
 export async function signUp(email, password) {
   try {
@@ -41,9 +42,11 @@ export async function signOut() {
     } else {
       console.log('signOut success')
     }
+    clearCachedUserId()
     return result
   } catch (error) {
     console.error('unexpected signOut error:', error)
+    clearCachedUserId()
     return { error }
   }
 }

--- a/src/utils/authCache.js
+++ b/src/utils/authCache.js
@@ -1,0 +1,19 @@
+let cachedUserId = null
+
+export async function getCurrentUserId(supabase) {
+  if (cachedUserId) return cachedUserId
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser()
+  if (error) {
+    cachedUserId = null
+    throw error
+  }
+  cachedUserId = user.id
+  return cachedUserId
+}
+
+export function clearCachedUserId() {
+  cachedUserId = null
+}

--- a/src/utils/pageRepository.js
+++ b/src/utils/pageRepository.js
@@ -1,4 +1,5 @@
 import { getSupabase } from './supabaseClient'
+import { getCurrentUserId, clearCachedUserId } from './authCache'
 
 const TABLE = 'pages'
 
@@ -16,19 +17,11 @@ function decodeTitle(name) {
 
 function handleUnauthorized(error) {
   if (error?.status === 401 || error?.message?.includes('not logged in')) {
+    clearCachedUserId()
     window.location.reload()
     return true
   }
   return false
-}
-
-async function getCurrentUserId(supabase) {
-  const {
-    data: { user },
-    error,
-  } = await supabase.auth.getUser()
-  if (error) throw error
-  return user.id
 }
 
 export async function listPages(projectId) {

--- a/src/utils/projectRepository.js
+++ b/src/utils/projectRepository.js
@@ -1,22 +1,15 @@
 import { getSupabase } from './supabaseClient'
+import { getCurrentUserId, clearCachedUserId } from './authCache'
 
 const TABLE = 'projects'
 
 function handleUnauthorized(error) {
   if (error?.status === 401 || error?.message?.includes('not logged in')) {
+    clearCachedUserId()
     window.location.reload()
     return true
   }
   return false
-}
-
-async function getCurrentUserId(supabase) {
-  const {
-    data: { user },
-    error,
-  } = await supabase.auth.getUser()
-  if (error) throw error
-  return user.id
 }
 
 export async function listProjects() {


### PR DESCRIPTION
## Summary
- add auth cache helper to memoize current user ID
- use cached ID in page and project repositories and clear it on auth errors
- reset auth cache on sign-out

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897cd4ccb58832184ff715f6e0724a9