### PR TITLE
Refactor page state to use IDs and update sidebar

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -80,14 +80,19 @@ export default function App({ onSignOut }) {
   async function loadProjectPages(projectId) {
     try {
       const pageList = await listScripts(projectId)
+      const ids = pageList.map(p => (typeof p === 'object' ? p.id : p))
       const pagesData = await Promise.all(
-        pageList.map(p => readScript(p.id, projectId).catch(() => ({ page_content: null })))
+        ids.map(id => readScript(id, projectId).catch(() => ({ page_content: null, metadata: {} }))),
       )
-      const docs = pagesData.map((p) => {
+      const docs = pagesData.map(p => {
         const doc = p?.page_content ?? { type: 'doc', content: [{ type: 'pageHeader' }] }
         return typeof doc === 'string' ? JSON.parse(doc) : doc
       })
-      setPages(pageList)
+      const pageInfo = pagesData.map((p, idx) => ({
+        id: ids[idx],
+        title: p?.metadata?.title ?? `Page ${idx + 1}`,
+      }))
+      setPages(pageInfo)
       setPageDocs(docs)
       activePageRef.current = 0
       setActivePage(0)
@@ -100,12 +105,12 @@ export default function App({ onSignOut }) {
 
   function extractTitle(pageDoc) {
     const header = pageDoc.content?.[0]
-    if (!header) return 'Untitled Page'
+    if (!header) return null
     const text = (header.content || [])
-      .map((c) => c.text || '')
+      .map(c => c.text || '')
       .join('')
       .trim()
-    return text || 'Untitled Page'
+    return text || null
   }
 
   function logDev(message) {
@@ -113,14 +118,19 @@ export default function App({ onSignOut }) {
   }
 
   function handlePageUpdate(index, doc, text) {
-      const title = extractTitle(doc)
-      const current = pages[index] || {}
-      setPages(prev => {
-        const next = [...prev]
-        const page = next[index] || {}
-        next[index] = { ...page, title }
-        return next
-      })
+    const current = pages[index] || {}
+    const extracted = extractTitle(doc)
+    const pageId = current.id
+    const finalTitle = extracted !== null ? extracted : current.title
+
+    setPages(prev => {
+      const next = [...prev]
+      const page = next[index] || {}
+      if (extracted !== null) {
+        next[index] = { ...page, title: extracted }
+      }
+      return next
+    })
     setPageDocs(prev => {
       const next = [...prev]
       next[index] = doc
@@ -132,27 +142,13 @@ export default function App({ onSignOut }) {
     setIsSaving(true)
     clearTimeout(saveTimeoutsRef.current[index])
     saveTimeoutsRef.current[index] = setTimeout(async () => {
-      if (activeProject) {
+      if (activeProject && pageId) {
         try {
-          if (current.id) {
-            await updateScript(
-              current.id,
-              { page_content: doc, metadata: { title, version: 1 } },
-              activeProject.id,
-            )
-          } else {
-            const newId = await createScript(
-              title,
-              { page_content: doc, metadata: { version: 1 } },
-              activeProject.id,
-            )
-            setPages(prev => {
-              const next = [...prev]
-              const page = next[index] || {}
-              next[index] = { ...page, id: newId, title }
-              return next
-            })
-          }
+          await updateScript(
+            pageId,
+            { page_content: doc, metadata: { title: finalTitle, version: 1 } },
+            activeProject.id,
+          )
           logDev('Save complete')
         } catch (err) {
           console.error('Error saving page:', err)
@@ -161,7 +157,7 @@ export default function App({ onSignOut }) {
           setIsSaving(false)
         }
       } else {
-        logDev('No active project; save skipped')
+        logDev('No active project or page id; save skipped')
         setIsSaving(false)
       }
     }, 500)
@@ -180,10 +176,23 @@ export default function App({ onSignOut }) {
     }
   }
 
-  function handleCreatePage() {
+  async function handleCreatePage() {
     const newDoc = { type: 'doc', content: [{ type: 'pageHeader' }] }
     const newIndex = pages.length
-    setPages(prev => [...prev, { id: null, title: 'Untitled Page' }])
+    const title = `Page ${newIndex + 1}`
+    let newId = null
+    if (activeProject) {
+      try {
+        newId = await createScript(
+          title,
+          { page_content: newDoc, metadata: { title, version: 1 } },
+          activeProject.id,
+        )
+      } catch (err) {
+        console.error('Error creating page:', err)
+      }
+    }
+    setPages(prev => [...prev, { id: newId, title }])
     setPageDocs(prev => [...prev, newDoc])
     setTimeout(() => {
       const el = pageRefs.current[newIndex]
@@ -195,7 +204,7 @@ export default function App({ onSignOut }) {
     <div className="app-layout">
       <Sidebar
         ref={sidebarRef}
-        pages={pages.map(p => p.title)}
+        pages={pages}
         activePage={activePage}
         onSelectProject={handleSelectProject}
         onSelectPage={handleNavigatePage}

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -21,14 +21,14 @@ function PageNavigator({ pages = [], activePage = 0, onSelectPage, onCreatePage 
       <h4 className="section-heading">Pages</h4>
       <ul className="page-list">
         {pages.length === 0 && <li className="empty-message">No pages</li>}
-        {pages.map((title, idx) => (
+        {pages.map((page, idx) => (
           <li
-            key={idx}
+            key={page.id ?? idx}
             className={cn('page-item', idx === activePage && 'active')}
             onClick={() => onSelectPage?.(idx)}
           >
             <div className="page-item-header">
-              <div className="font-medium">{title}</div>
+              <div className="font-medium">{page.title}</div>
             </div>
           </li>
         ))}


### PR DESCRIPTION
## Summary
- Store pages as `{id, title}` objects and track page docs separately, pulling titles from script metadata.
- Create new pages immediately to obtain an ID and update titles only when a non-empty header exists.
- Update sidebar navigation to work with page objects and display each page's title.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897cefafc288321956fba6c109a1674