### PR TITLE
Throttle page updates and stabilize ScriptEditor components

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -3,3 +3,26 @@ import { clsx } from 'clsx'
 export function cn(...inputs) {
   return clsx(inputs)
 }
+
+export function throttle(fn, wait) {
+  let timeout = null
+  let lastCall = 0
+  return (...args) => {
+    const now = Date.now()
+    const remaining = wait - (now - lastCall)
+    if (remaining <= 0) {
+      if (timeout) {
+        clearTimeout(timeout)
+        timeout = null
+      }
+      lastCall = now
+      fn(...args)
+    } else if (!timeout) {
+      timeout = setTimeout(() => {
+        lastCall = Date.now()
+        timeout = null
+        fn(...args)
+      }, remaining)
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Throttle `handlePageUpdate` to reduce rapid state churn and stabilize callback identities
- Export reusable `throttle` helper in `lib/utils`
- Use page ids as stable keys for `ScriptEditor` instances

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898c94b936483218e857b0c9f44d116