### PR TITLE
feat: sync sidebar with editor scroll

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -39,6 +39,7 @@ export default function App({ onSignOut }) {
   const [accentColor, setAccentColor] = useState('#2563eb')
   const [showDevInfo, setShowDevInfo] = useState(false)
   const pageRefs = useRef([])
+  const pageTextsRef = useRef([])
   const saveTimeoutsRef = useRef({})
   const [zoom, setZoom] = useState(1)
 
@@ -171,6 +172,31 @@ export default function App({ onSignOut }) {
     [handlePageUpdate],
   )
 
+  function handleNavigatePage(index, userInitiated) {
+    if (!userInitiated) return
+    const el = pageRefs.current[index]
+    if (!el) return
+    isNavigatingRef.current = true
+    activePageRef.current = index
+    setActivePage(index)
+    el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    setTimeout(() => {
+      isNavigatingRef.current = false
+    }, 300)
+  }
+
+  function handlePageInView(index, editor) {
+    if (isNavigatingRef.current) return
+    if (index !== activePageRef.current) {
+      activePageRef.current = index
+      setActivePage(index)
+    }
+    const text = editor?.getText?.() ?? ''
+    pageTextsRef.current[index] = text
+    const words = text.trim().split(/\s+/).filter(Boolean)
+    setWordCount(words.length)
+  }
+
   async function handleCreatePage() {
     const newDoc = { type: 'doc', content: [{ type: 'pageHeader' }] }
     const newIndex = pages.length
@@ -210,6 +236,7 @@ export default function App({ onSignOut }) {
         ref={sidebarRef}
         pages={pages}
         activePage={activePage}
+        onSelectPage={handleNavigatePage}
         onSelectProject={handleSelectProject}
         onCreatePage={handleCreatePage}
         onSignOut={onSignOut}
@@ -227,6 +254,7 @@ export default function App({ onSignOut }) {
             mode={mode}
             pageIndex={idx}
             onUpdate={throttledHandlePageUpdate}
+            onInView={handlePageInView}
             characters={activeProject?.characters ?? []}
             zoom={zoom}
           />


### PR DESCRIPTION
## Summary
- scroll to pages via sidebar clicks with handleNavigatePage
- track active page and word count when editors enter view

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898d9061b388321ad8e57a13a36f221