### PR TITLE
fix editor height handling

### DIFF
--- a/src/components/ScriptEditor.jsx
+++ b/src/components/ScriptEditor.jsx
@@ -139,7 +139,7 @@ const ScriptEditor = forwardRef(function ScriptEditor(
       className="editor-wrapper"
       style={{
         width: `${PAGE_WIDTH * zoom}px`,
-        minHeight: `${PAGE_HEIGHT * zoom}px`,
+        height: `${PAGE_HEIGHT * zoom}px`,
         transformOrigin: 'top left',
         transform: `scale(${zoom})`,
       }}

--- a/src/index.css
+++ b/src/index.css
@@ -313,7 +313,7 @@ body {
 .editor-content {
   box-sizing: border-box;
   width: 100%;
-  height: 100%;
+  min-height: 100%;
   background: var(--bg-panel);
   margin: 0;
   padding: 1in;
@@ -324,7 +324,6 @@ body {
 
 .editor-content .ProseMirror {
   min-height: 100%;
-  height: 100%;
 }
 
 .page-wrapper {


### PR DESCRIPTION
## Summary
- ensure ScriptEditor wrapper defines explicit height so children can size to 100%
- switch editor-content styles to use `min-height`, letting ProseMirror fill the page

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898d916dd588321b4b58a4b36c5dd15