### PR TITLE
feat: track per-page word counts

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,6 +22,20 @@ function extractTitle(pageDoc) {
   return text || null
 }
 
+function countWords(text) {
+  if (!text) return 0
+  return text.trim().split(/\s+/).filter(Boolean).length
+}
+
+function getTextFromDoc(node) {
+  if (!node) return ''
+  if (node.text) return node.text
+  if (Array.isArray(node.content)) {
+    return node.content.map(getTextFromDoc).join(' ')
+  }
+  return ''
+}
+
 export default function App({ onSignOut }) {
   const [activeProject, setActiveProject] = useState(null)
   const [isSaving, setIsSaving] = useState(false)
@@ -33,6 +47,7 @@ export default function App({ onSignOut }) {
   const activePageRef = useRef(0)
   const isNavigatingRef = useRef(false)
   const [wordCount, setWordCount] = useState(0)
+  const wordCountsRef = useRef([])
   const sidebarRef = useRef(null)
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [theme, setTheme] = useState('light')
@@ -106,9 +121,12 @@ export default function App({ onSignOut }) {
       }))
       setPages(pageInfo)
       setPageDocs(docs)
+      const counts = docs.map(d => countWords(getTextFromDoc(d)))
+      wordCountsRef.current = counts
+      const total = counts.reduce((sum, c) => sum + c, 0)
       activePageRef.current = 0
       setActivePage(0)
-      setWordCount(0)
+      setWordCount(total)
     } catch (err) {
       console.error('Error loading project pages:', err)
     }
@@ -121,7 +139,7 @@ export default function App({ onSignOut }) {
     setDevLogs(logs => [...logs.slice(-9), message])
   }, [])
 
-  const handlePageUpdate = useCallback((index, doc) => {
+  const handlePageUpdate = useCallback((index, doc, editor) => {
     const current = pagesRef.current[index] || {}
     const extracted = extractTitle(doc)
     const pageId = current.id
@@ -140,6 +158,11 @@ export default function App({ onSignOut }) {
       next[index] = doc
       return next
     })
+
+    const text = editor?.getText ? editor.getText() : getTextFromDoc(doc)
+    wordCountsRef.current[index] = countWords(text)
+    const total = wordCountsRef.current.reduce((sum, c) => sum + c, 0)
+    setWordCount(total)
 
     setIsSaving(true)
     clearTimeout(saveTimeoutsRef.current[index])
@@ -166,6 +189,18 @@ export default function App({ onSignOut }) {
     }, 500)
   }, [logDev])
 
+  const handlePageInView = useCallback((index, editor) => {
+    if (isNavigatingRef.current) return
+    if (activePageRef.current !== index) {
+      activePageRef.current = index
+      setActivePage(index)
+    }
+    const text = editor?.getText ? editor.getText() : ''
+    wordCountsRef.current[index] = countWords(text)
+    const total = wordCountsRef.current.reduce((sum, c) => sum + c, 0)
+    setWordCount(total)
+  }, [])
+
   const throttledHandlePageUpdate = useMemo(
     () => throttle(handlePageUpdate, 200),
     [handlePageUpdate],
@@ -189,13 +224,15 @@ export default function App({ onSignOut }) {
     }
     setPages(prev => [...prev, { id: newId, title }])
     setPageDocs(prev => [...prev, newDoc])
+    wordCountsRef.current[newIndex] = 0
     setTimeout(() => {
       const el = pageRefs.current[newIndex]
       if (el && activePageRef.current !== newIndex) {
         isNavigatingRef.current = true
         activePageRef.current = newIndex
         setActivePage(newIndex)
-        setWordCount(0)
+        const total = wordCountsRef.current.reduce((sum, c) => sum + c, 0)
+        setWordCount(total)
         el.scrollIntoView({ behavior: 'smooth', block: 'start' })
         setTimeout(() => {
           isNavigatingRef.current = false
@@ -227,6 +264,7 @@ export default function App({ onSignOut }) {
             mode={mode}
             pageIndex={idx}
             onUpdate={throttledHandlePageUpdate}
+            onInView={handlePageInView}
             characters={activeProject?.characters ?? []}
             zoom={zoom}
           />


### PR DESCRIPTION
## Summary
- reintroduce word counting helper and per-page word count tracking
- update page editing and visibility handlers to refresh counts and totals
- feed counts into DevInfo overlay

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898d90b81708321b8e0f83d7c2fa1ee