### PR TITLE
Improve page active tracking using intersection ratios

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -31,6 +31,7 @@ export default function App({ onSignOut }) {
   const [pageDocs, setPageDocs] = useState([])   // ProseMirror JSON per page
   const [activePage, setActivePage] = useState(0)
   const activePageRef = useRef(0)
+  const activePageRatioRef = useRef(0)
   const isNavigatingRef = useRef(false)
   const [wordCount, setWordCount] = useState(0)
   const sidebarRef = useRef(null)
@@ -178,17 +179,21 @@ export default function App({ onSignOut }) {
     if (!el) return
     isNavigatingRef.current = true
     activePageRef.current = index
+    activePageRatioRef.current = 1
     setActivePage(index)
-    el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    el.scrollIntoView({ behavior: 'smooth', block: 'center' })
     setTimeout(() => {
       isNavigatingRef.current = false
     }, 300)
   }
 
-  function handlePageInView(index, editor) {
+  function handlePageInView(index, editor, ratio) {
     if (isNavigatingRef.current) return
-    if (index !== activePageRef.current) {
+    if (index === activePageRef.current) {
+      activePageRatioRef.current = ratio
+    } else if (ratio > 0.6 || ratio > activePageRatioRef.current) {
       activePageRef.current = index
+      activePageRatioRef.current = ratio
       setActivePage(index)
     }
     const text = editor?.getText?.() ?? ''

--- a/src/components/ScriptEditor.jsx
+++ b/src/components/ScriptEditor.jsx
@@ -106,7 +106,7 @@ const ScriptEditor = forwardRef(function ScriptEditor(
       entries => {
         for (const e of entries) {
           if (e.isIntersecting) {
-            onInViewRef.current?.(pageIndex, editor)
+            onInViewRef.current?.(pageIndex, editor, e.intersectionRatio)
             break
           }
         }


### PR DESCRIPTION
## Summary
- pass intersection ratios from ScriptEditor observers to parent
- track page view ratios in App to avoid sidebar highlight bouncing
- center pages during navigation so prior page fully exits view

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run dev` (started and then stopped)


------
https://chatgpt.com/codex/tasks/task_e_6898dd861b1c832189c9783601537c91