### PR TITLE
Suppress editor scroll bounce

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -310,6 +310,11 @@ body {
   border-radius: var(--radius);
 }
 
+.editor-wrapper {
+  overscroll-behavior: contain;
+  touch-action: pan-y;
+}
+
 .editor-content {
   box-sizing: border-box;
   width: 100%;
@@ -318,6 +323,8 @@ body {
   margin: 0;
   padding: 1in;
   overflow: hidden;
+  overscroll-behavior: contain;
+  touch-action: pan-y;
   border-radius: 0;
   box-shadow: 0 0 15px rgba(0, 0, 0, 0.4);
 }


### PR DESCRIPTION
## Summary
- prevent bounce physics by containing overscroll on editor wrapper and content
- allow vertical touch panning on editor for mobile devices

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898e48897d08321b21e8f7809a35019