### PR TITLE
fix: prevent viewport scroll when focusing editor

### DIFF
--- a/src/components/ScriptEditor.jsx
+++ b/src/components/ScriptEditor.jsx
@@ -149,7 +149,13 @@ const ScriptEditor = forwardRef(function ScriptEditor(
           {/* Keep your existing buttons; example for underline */}
           <button
             className={`btn ${editor.isActive('underline') ? 'active' : ''}`}
-            onClick={() => editor.chain().focus().toggleUnderline().run()}
+            onClick={() =>
+              editor
+                .chain()
+                .focus(undefined, { scrollIntoView: false })
+                .toggleUnderline()
+                .run()
+            }
             type="button"
           >
             U

--- a/src/extensions/SlashCommand.js
+++ b/src/extensions/SlashCommand.js
@@ -14,37 +14,67 @@ const SlashCommand = Extension.create({
             {
               title: 'Page Header',
               command: ({ editor, range }) => {
-                editor.chain().focus().deleteRange(range).setPageHeader().run()
+                editor
+                  .chain()
+                  .focus(undefined, { scrollIntoView: false })
+                  .deleteRange(range)
+                  .setPageHeader()
+                  .run()
               },
             },
             {
               title: 'Panel Header',
               command: ({ editor, range }) => {
-                editor.chain().focus().deleteRange(range).setPanelHeader().run()
+                editor
+                  .chain()
+                  .focus(undefined, { scrollIntoView: false })
+                  .deleteRange(range)
+                  .setPanelHeader()
+                  .run()
               },
             },
             {
               title: 'Description',
               command: ({ editor, range }) => {
-                editor.chain().focus().deleteRange(range).setDescription().run()
+                editor
+                  .chain()
+                  .focus(undefined, { scrollIntoView: false })
+                  .deleteRange(range)
+                  .setDescription()
+                  .run()
               },
             },
             {
               title: 'Character',
               command: ({ editor, range }) => {
-                editor.chain().focus().deleteRange(range).setCharacter().run()
+                editor
+                  .chain()
+                  .focus(undefined, { scrollIntoView: false })
+                  .deleteRange(range)
+                  .setCharacter()
+                  .run()
               },
             },
             {
               title: 'Dialogue',
               command: ({ editor, range }) => {
-                editor.chain().focus().deleteRange(range).setDialogue().run()
+                editor
+                  .chain()
+                  .focus(undefined, { scrollIntoView: false })
+                  .deleteRange(range)
+                  .setDialogue()
+                  .run()
               },
             },
             {
               title: 'Cue Label',
               command: ({ editor, range }) => {
-                editor.chain().focus().deleteRange(range).setCueLabel().run()
+                editor
+                  .chain()
+                  .focus(undefined, { scrollIntoView: false })
+                  .deleteRange(range)
+                  .setCueLabel()
+                  .run()
               },
             },
             {
@@ -52,7 +82,7 @@ const SlashCommand = Extension.create({
               command: ({ editor, range }) => {
                 editor
                   .chain()
-                  .focus()
+                  .focus(undefined, { scrollIntoView: false })
                   .deleteRange(range)
                   .setCueContent()
                   .run()
@@ -61,19 +91,34 @@ const SlashCommand = Extension.create({
             {
               title: 'SFX',
               command: ({ editor, range }) => {
-                editor.chain().focus().deleteRange(range).setSfx().run()
+                editor
+                  .chain()
+                  .focus(undefined, { scrollIntoView: false })
+                  .deleteRange(range)
+                  .setSfx()
+                  .run()
               },
             },
             {
               title: 'Notes',
               command: ({ editor, range }) => {
-                editor.chain().focus().deleteRange(range).setNotes().run()
+                editor
+                  .chain()
+                  .focus(undefined, { scrollIntoView: false })
+                  .deleteRange(range)
+                  .setNotes()
+                  .run()
               },
             },
             {
               title: 'No Copy',
               command: ({ editor, range }) => {
-                editor.chain().focus().deleteRange(range).setNoCopy().run()
+                editor
+                  .chain()
+                  .focus(undefined, { scrollIntoView: false })
+                  .deleteRange(range)
+                  .setNoCopy()
+                  .run()
               },
             },
           ].filter(item =>

--- a/src/extensions/SmartFlow.js
+++ b/src/extensions/SmartFlow.js
@@ -23,7 +23,11 @@ const SmartFlow = Extension.create({
         const currentType = $from.parent.type.name
         const nextType = flowMap[currentType]
         if (!nextType) return false
-        this.editor.chain().focus().insertContent({ type: nextType }).run()
+        this.editor
+          .chain()
+          .focus(undefined, { scrollIntoView: false })
+          .insertContent({ type: nextType })
+          .run()
         return true
       },
       Tab: () => {
@@ -33,11 +37,15 @@ const SmartFlow = Extension.create({
         const nextPos = $from.after()
         const nextNode = this.editor.state.doc.nodeAt(nextPos)
         if (nextNode && !isBoundary(nextNode.type.name)) {
-          this.editor.commands.focus(nextPos)
+          this.editor.commands.focus(nextPos, { scrollIntoView: false })
           return true
         }
         if (!nextType) return false
-        this.editor.chain().focus().insertContent({ type: nextType }).run()
+        this.editor
+          .chain()
+          .focus(undefined, { scrollIntoView: false })
+          .insertContent({ type: nextType })
+          .run()
         return true
       },
       'Shift-Tab': () => {
@@ -45,7 +53,7 @@ const SmartFlow = Extension.create({
         const prevPos = $from.before()
         const prevNode = this.editor.state.doc.nodeAt(prevPos)
         if (!prevNode || isBoundary(prevNode.type.name) && prevNode.type.name !== 'panelHeader') return false
-        this.editor.commands.focus(prevPos)
+        this.editor.commands.focus(prevPos, { scrollIntoView: false })
         return true
       },
     }
@@ -60,7 +68,7 @@ const SmartFlow = Extension.create({
         })
         const number = count + 1
         chain()
-          .focus()
+          .focus(undefined, { scrollIntoView: false })
           .deleteRange(range)
           .insertContent([
             {

--- a/src/extensions/customNodes.js
+++ b/src/extensions/customNodes.js
@@ -148,7 +148,7 @@ export const Character = Node.create({
         command: ({ editor, range, props }) => {
           editor
             .chain()
-            .focus()
+            .focus(undefined, { scrollIntoView: false })
             .deleteRange(range)
             .insertContent(props)
             .run()


### PR DESCRIPTION
## Summary
- avoid scrolling viewport when focusing editor
- update SmartFlow and SlashCommand actions to focus without scrolling
- ensure character suggestion commands keep focus without scroll

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898e47ed9f4832185f5b92ea0b3e10f