### PR TITLE
Decouple page navigation from editor

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -44,9 +44,6 @@ export default function App({ onSignOut }) {
   const [pages, setPages] = useState([])         // [{ id, title, ... }]
   const [pageDocs, setPageDocs] = useState([])   // ProseMirror JSON per page
   const [activePage, setActivePage] = useState(0)
-  const activePageRef = useRef(0)
-  const activePageRatioRef = useRef(0)
-  const lastInteractionRef = useRef('editor')
   const [wordCount, setWordCount] = useState(0)
   const wordCountsRef = useRef([])
   const sidebarRef = useRef(null)
@@ -68,10 +65,6 @@ export default function App({ onSignOut }) {
     document.documentElement.setAttribute('data-theme', theme)
   }, [theme])
 
-
-  useEffect(() => {
-    activePageRef.current = activePage
-  }, [activePage])
 
   useEffect(() => {
     document.documentElement.style.setProperty('--accent', accentColor)
@@ -125,7 +118,6 @@ export default function App({ onSignOut }) {
       const counts = docs.map(d => countWords(getTextFromDoc(d)))
       wordCountsRef.current = counts
       const total = counts.reduce((sum, c) => sum + c, 0)
-      activePageRef.current = 0
       setActivePage(0)
       setWordCount(total)
     } catch (err) {
@@ -199,31 +191,8 @@ export default function App({ onSignOut }) {
     if (!userInitiated) return
     const el = pageRefs.current[index]
     if (!el) return
-    lastInteractionRef.current = 'sidebar'
-    activePageRef.current = index
-    activePageRatioRef.current = 1
     setActivePage(index)
     el.scrollIntoView({ behavior: 'smooth', block: 'center' })
-  }
-
-  function handlePageInView(index, editor, ratio) {
-    if (lastInteractionRef.current === 'sidebar') {
-      if (index !== activePageRef.current || ratio < 1) return
-      lastInteractionRef.current = 'editor'
-    } else {
-      lastInteractionRef.current = 'editor'
-    }
-    if (index === activePageRef.current) {
-      activePageRatioRef.current = ratio
-    } else if (ratio > 0.6 || ratio > activePageRatioRef.current) {
-      activePageRef.current = index
-      activePageRatioRef.current = ratio
-      setActivePage(index)
-    }
-    const text = editor?.getText ? editor.getText() : ''
-    wordCountsRef.current[index] = countWords(text)
-    const total = wordCountsRef.current.reduce((sum, c) => sum + c, 0)
-    setWordCount(total)
   }
 
   async function handleCreatePage() {
@@ -247,10 +216,7 @@ export default function App({ onSignOut }) {
     wordCountsRef.current[newIndex] = 0
     setTimeout(() => {
       const el = pageRefs.current[newIndex]
-      if (el && activePageRef.current !== newIndex) {
-        lastInteractionRef.current = 'sidebar'
-        activePageRef.current = newIndex
-        activePageRatioRef.current = 1
+      if (el) {
         setActivePage(newIndex)
         const total = wordCountsRef.current.reduce((sum, c) => sum + c, 0)
         setWordCount(total)
@@ -283,7 +249,6 @@ export default function App({ onSignOut }) {
             mode={mode}
             pageIndex={idx}
             onUpdate={throttledHandlePageUpdate}
-            onInView={handlePageInView}
             characters={activeProject?.characters ?? []}
             zoom={zoom}
           />

--- a/src/components/ScriptEditor.jsx
+++ b/src/components/ScriptEditor.jsx
@@ -29,7 +29,6 @@ const ScriptEditor = forwardRef(function ScriptEditor(
     mode,            // kept to preserve behavior / styling toggles
     pageIndex,
     onUpdate,
-    onInView,
     characters = [],
     zoom = 1,
   },
@@ -42,9 +41,7 @@ const ScriptEditor = forwardRef(function ScriptEditor(
   // Keep the latest callbacks in refs so their identity can change
   // without forcing the editor to re-create.
   const onUpdateRef = useRef(onUpdate)
-  const onInViewRef = useRef(onInView)
   useEffect(() => { onUpdateRef.current = onUpdate }, [onUpdate])
-  useEffect(() => { onInViewRef.current = onInView }, [onInView])
 
   // Memoize extensions so `useEditor` receives a stable config.
   const extensions = useMemo(() => ([
@@ -76,7 +73,7 @@ const ScriptEditor = forwardRef(function ScriptEditor(
     },
   }), [pageIndex])
 
-  // IMPORTANT: do not put onUpdate / onInView directly into useEditor.
+  // IMPORTANT: do not put onUpdate directly into useEditor.
   // We attach listeners after mount to keep config stable.
   const editor = useEditor({
     extensions,
@@ -96,25 +93,6 @@ const ScriptEditor = forwardRef(function ScriptEditor(
     return () => {
       editor.off('update', handleUpdate)
     }
-  }, [editor, pageIndex])
-
-  // Optional: observe visibility for onInView without recreating editor
-  useEffect(() => {
-    if (!editor || !containerRef.current) return
-    const el = containerRef.current
-    const io = new IntersectionObserver(
-      entries => {
-        for (const e of entries) {
-          if (e.isIntersecting) {
-            onInViewRef.current?.(pageIndex, editor, e.intersectionRatio)
-            break
-          }
-        }
-      },
-      { root: null, rootMargin: '0px', threshold: 0.4 },
-    )
-    io.observe(el)
-    return () => io.disconnect()
   }, [editor, pageIndex])
 
   // Apply character suggestions from project as a side-effect


### PR DESCRIPTION
## Summary
- Remove editor-driven page navigation logic and drop onInView prop
- Simplify ScriptEditor to expose only update callback

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689948ec95288321bb8a5fb7bfad2456