### PR TITLE
feat: add environment-aware logger and unify auth responses

### DIFF
--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { signIn, signUp } from '../utils/auth.js'
+import { logger } from '../utils/logger.js'
 import { Button } from './ui/button'
 
 export default function Login({ onLogin }) {
@@ -30,22 +31,13 @@ export default function Login({ onLogin }) {
       return
     }
 
-    let result
-    try {
-      if (isSignUp) {
-        result = await signUp(trimmedEmail, trimmedPassword)
-      } else {
-        result = await signIn(trimmedEmail, trimmedPassword)
-      }
-    } catch (err) {
-      console.error('Unexpected auth error:', err)
-      setError(err.message)
-      return
-    }
+    const result = isSignUp
+      ? await signUp(trimmedEmail, trimmedPassword)
+      : await signIn(trimmedEmail, trimmedPassword)
 
     const { data, error: err } = result
     if (err) {
-      console.error('Auth error:', err)
+      logger.error('Auth error:', err)
       setError(err.message)
     } else {
       onLogin?.(data.session)

--- a/src/components/SettingsSidebar.jsx
+++ b/src/components/SettingsSidebar.jsx
@@ -1,6 +1,7 @@
 import { Button } from './ui/button'
 import { cn } from '../lib/utils'
 import { signOut } from '../utils/auth.js'
+import { logger } from '../utils/logger.js'
 
 export default function SettingsSidebar({
   open,
@@ -13,11 +14,11 @@ export default function SettingsSidebar({
   setShowDevInfo,
 }) {
   async function handleSignOut() {
-    try {
-      await signOut()
+    const { error } = await signOut()
+    if (error) {
+      logger.error('signOut failed:', error)
+    } else {
       onSignOut?.()
-    } catch (err) {
-      console.error('signOut failed:', err.message)
     }
   }
 

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -1,52 +1,56 @@
 import { supabase } from './supabaseClient.js'
 import { clearCachedUserId } from './authCache.js'
+import { logger } from './logger.js'
 
 export async function signUp(email, password) {
+  logger.log('Attempting signUp for', email)
   try {
-    console.log('Attempting signUp for', email)
-    const result = await supabase.auth.signUp({ email, password })
-    if (result.error) {
-      console.error('signUp error:', result.error)
+    const { data, error } = await supabase.auth.signUp({ email, password })
+    if (error) {
+      logger.error('signUp error:', error)
     } else {
-      console.log('signUp success for user', result.data.user?.id)
+      logger.log('signUp success for user', data.user?.id)
     }
-    return result
+    return { data, error }
   } catch (error) {
-    console.error('unexpected signUp error:', error)
+    logger.error('unexpected signUp error:', error)
     return { data: null, error }
   }
 }
 
 export async function signIn(email, password) {
+  logger.log('Attempting signIn for', email)
   try {
-    console.log('Attempting signIn for', email)
-    const result = await supabase.auth.signInWithPassword({ email, password })
-    if (result.error) {
-      console.error('signIn error:', result.error)
+    const { data, error } = await supabase.auth.signInWithPassword({
+      email,
+      password,
+    })
+    if (error) {
+      logger.error('signIn error:', error)
     } else {
-      console.log('signIn success for user', result.data.user?.id)
+      logger.log('signIn success for user', data.user?.id)
     }
-    return result
+    return { data, error }
   } catch (error) {
-    console.error('unexpected signIn error:', error)
+    logger.error('unexpected signIn error:', error)
     return { data: null, error }
   }
 }
 
 export async function signOut() {
+  logger.log('Signing out current user')
   try {
-    console.log('Signing out current user')
-    const result = await supabase.auth.signOut()
-    if (result.error) {
-      console.error('signOut error:', result.error)
+    const { error } = await supabase.auth.signOut()
+    if (error) {
+      logger.error('signOut error:', error)
     } else {
-      console.log('signOut success')
+      logger.log('signOut success')
     }
     clearCachedUserId()
-    return result
+    return { data: null, error }
   } catch (error) {
-    console.error('unexpected signOut error:', error)
+    logger.error('unexpected signOut error:', error)
     clearCachedUserId()
-    return { error }
+    return { data: null, error }
   }
 }

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,0 +1,16 @@
+const isDev = import.meta.env.DEV
+
+export const logger = {
+  log: (...args) => {
+    if (isDev) console.log(...args)
+  },
+  info: (...args) => {
+    if (isDev) console.info(...args)
+  },
+  warn: (...args) => {
+    if (isDev) console.warn(...args)
+  },
+  error: (...args) => {
+    console.error(...args)
+  },
+}


### PR DESCRIPTION
## Summary
- add simple logger that hides non-error logs in production
- refactor auth helpers to use logger and always return `{ data, error }`
- update login and settings components to handle unified auth results

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run test:supabase` *(fails: Missing VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY environment variables.)*


------
https://chatgpt.com/codex/tasks/task_e_6899528bd8088321ba7f304bc581701b