### PR TITLE
Refactor unauthorized session handling into shared utility

### DIFF
--- a/src/utils/pageRepository.js
+++ b/src/utils/pageRepository.js
@@ -1,6 +1,7 @@
 // utils/pageRepository.js
 import { supabase } from './supabaseClient'
-import { getCurrentUserId, clearCachedUserId } from './authCache'
+import { getCurrentUserId } from './authCache'
+import { handleUnauthorized } from './session'
 
 const TABLE = 'pages'
 
@@ -14,15 +15,6 @@ function decodeTitle(name) {
   } catch {
     return name
   }
-}
-
-function handleUnauthorized(error) {
-  if (error?.status === 401 || error?.message?.includes('not logged in')) {
-    clearCachedUserId()
-    window.location.reload()
-    return true
-  }
-  return false
 }
 
 function getClient() {

--- a/src/utils/projectRepository.js
+++ b/src/utils/projectRepository.js
@@ -1,17 +1,9 @@
 // utils/projectRepository.js
 import { supabase } from './supabaseClient'
-import { getCurrentUserId, clearCachedUserId } from './authCache'
+import { getCurrentUserId } from './authCache'
+import { handleUnauthorized } from './session'
 
 const TABLE = 'projects'
-
-function handleUnauthorized(error) {
-  if (error?.status === 401 || error?.message?.includes('not logged in')) {
-    clearCachedUserId()
-    window.location.reload()
-    return true
-  }
-  return false
-}
 
 function getClient() {
   return supabase

--- a/src/utils/session.js
+++ b/src/utils/session.js
@@ -1,0 +1,10 @@
+import { clearCachedUserId } from './authCache'
+
+export function handleUnauthorized(error) {
+  if (error?.status === 401 || error?.message?.includes('not logged in')) {
+    clearCachedUserId()
+    window.location.reload()
+    return true
+  }
+  return false
+}


### PR DESCRIPTION
## Summary
- centralize unauthorized session logic in new `session.js`
- reuse `handleUnauthorized` across page and project repositories

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6899527ea7d88321a03e0b63c016184e