### PR TITLE
Add Supabase env validation and error handling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,7 +4,6 @@ import Sidebar from './components/Sidebar'
 import ScriptEditor from './components/ScriptEditor'
 import DevInfo from './components/DevInfo'
 import { listScripts, readScript, updateScript, createScript } from './utils/scriptRepository'
-import { supabase } from './utils/supabaseClient'
 import SettingsSidebar from './components/SettingsSidebar'
 import { Button } from './components/ui/button'
 import { cn, throttle } from './lib/utils'
@@ -36,7 +35,7 @@ function getTextFromDoc(node) {
   return ''
 }
 
-export default function App({ onSignOut }) {
+export default function App({ onSignOut, supabase }) {
   const [activeProject, setActiveProject] = useState(null)
   const [isSaving, setIsSaving] = useState(false)
   const [devLogs, setDevLogs] = useState([])
@@ -228,7 +227,7 @@ export default function App({ onSignOut }) {
 
   return (
     <div className="app-layout">
-      <Sidebar
+        <Sidebar
         ref={sidebarRef}
         pages={pages}
         activePage={activePage}
@@ -238,7 +237,7 @@ export default function App({ onSignOut }) {
         onSignOut={onSignOut}
         currentMode={mode}
         onModeChange={setMode}
-        supabase={supabase}
+          supabase={supabase}
       />
 
       <div className={cn('main-content', settingsOpen && 'shifted')}>

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -1,9 +1,19 @@
-import { supabase } from './supabaseClient.js'
 import { clearCachedUserId } from './authCache.js'
+
+async function getClient() {
+  try {
+    const { supabase } = await import('./supabaseClient.js')
+    return supabase
+  } catch (error) {
+    console.error('Failed to load Supabase client:', error?.message || error)
+    throw error
+  }
+}
 
 export async function signUp(email, password) {
   try {
     console.log('Attempting signUp for', email)
+    const supabase = await getClient()
     const result = await supabase.auth.signUp({ email, password })
     if (result.error) {
       console.error('signUp error:', result.error)
@@ -20,6 +30,7 @@ export async function signUp(email, password) {
 export async function signIn(email, password) {
   try {
     console.log('Attempting signIn for', email)
+    const supabase = await getClient()
     const result = await supabase.auth.signInWithPassword({ email, password })
     if (result.error) {
       console.error('signIn error:', result.error)
@@ -36,6 +47,7 @@ export async function signIn(email, password) {
 export async function signOut() {
   try {
     console.log('Signing out current user')
+    const supabase = await getClient()
     const result = await supabase.auth.signOut()
     if (result.error) {
       console.error('signOut error:', result.error)

--- a/src/utils/pageRepository.js
+++ b/src/utils/pageRepository.js
@@ -1,5 +1,4 @@
 // utils/pageRepository.js
-import { supabase } from './supabaseClient'
 import { getCurrentUserId, clearCachedUserId } from './authCache'
 
 const TABLE = 'pages'
@@ -25,15 +24,21 @@ function handleUnauthorized(error) {
   return false
 }
 
-function getClient() {
-  return supabase
+async function getClient() {
+  try {
+    const { supabase } = await import('./supabaseClient.js')
+    return supabase
+  } catch (error) {
+    console.error('Failed to load Supabase client:', error?.message || error)
+    throw error
+  }
 }
 
 // List pages for a project (returns [{ id, title }])
 export async function listPages(projectId) {
-  try {
-    const supabase = getClient()
-    const userId = await getCurrentUserId(supabase)
+    try {
+      const supabase = await getClient()
+      const userId = await getCurrentUserId(supabase)
     const { data, error } = await supabase
       .from(TABLE)
       .select('id, title')
@@ -54,10 +59,10 @@ export async function listPages(projectId) {
 
 // Create a page; returns new page id.
 export async function createPage(name, data, projectId) {
-  try {
-    const supabase = getClient()
-    const now = new Date().toISOString()
-    const userId = await getCurrentUserId(supabase)
+    try {
+      const supabase = await getClient()
+      const now = new Date().toISOString()
+      const userId = await getCurrentUserId(supabase)
     const payload = {
       title: encodeTitle(name),
       created_at: now,
@@ -86,9 +91,9 @@ export async function readPage(id, projectId) {
   if (!id) throw new Error('id required')
   if (!projectId) throw new Error('projectId required')
 
-  try {
-    const supabase = getClient()
-    const userId = await getCurrentUserId(supabase)
+    try {
+      const supabase = await getClient()
+      const userId = await getCurrentUserId(supabase)
     const { data, error } = await supabase
       .from(TABLE)
       .select('id, title, project_id, created_at, updated_at, page_content, version')
@@ -121,9 +126,9 @@ export async function updatePage(id, data, projectId) {
   if (!id) throw new Error('id required')
   if (!projectId) throw new Error('projectId required')
 
-  try {
-    const supabase = getClient()
-    const existing = await readPage(id, projectId)
+    try {
+      const supabase = await getClient()
+      const existing = await readPage(id, projectId)
     if (!existing) return null
 
     const updated = {
@@ -166,9 +171,9 @@ export async function deletePage(id, projectId) {
   if (!id) throw new Error('id required')
   if (!projectId) throw new Error('projectId required')
 
-  try {
-    const supabase = getClient()
-    const userId = await getCurrentUserId(supabase)
+    try {
+      const supabase = await getClient()
+      const userId = await getCurrentUserId(supabase)
     const { error } = await supabase
       .from(TABLE)
       .delete()

--- a/src/utils/projectRepository.js
+++ b/src/utils/projectRepository.js
@@ -1,5 +1,4 @@
 // utils/projectRepository.js
-import { supabase } from './supabaseClient'
 import { getCurrentUserId, clearCachedUserId } from './authCache'
 
 const TABLE = 'projects'
@@ -13,15 +12,21 @@ function handleUnauthorized(error) {
   return false
 }
 
-function getClient() {
-  return supabase
+async function getClient() {
+  try {
+    const { supabase } = await import('./supabaseClient.js')
+    return supabase
+  } catch (error) {
+    console.error('Failed to load Supabase client:', error?.message || error)
+    throw error
+  }
 }
 
 // List all projects for the current user.
 export async function listProjects() {
-  try {
-    const supabase = getClient()
-    const userId = await getCurrentUserId(supabase)
+    try {
+      const supabase = await getClient()
+      const userId = await getCurrentUserId(supabase)
     const { data, error } = await supabase
       .from(TABLE)
       .select('id, name, created_at, updated_at')
@@ -38,8 +43,8 @@ export async function listProjects() {
 
 // Create a new project (enforces unique name per user).
 export async function createProject(name, data = {}) {
-  try {
-    const supabase = getClient()
+    try {
+      const supabase = await getClient()
     const now = new Date().toISOString()
     const userId = await getCurrentUserId(supabase)
 
@@ -79,8 +84,8 @@ export async function createProject(name, data = {}) {
 // Read a project by ID (scoped to current user).
 export async function readProject(id) {
   if (!id) throw new Error('id required')
-  try {
-    const supabase = getClient()
+    try {
+      const supabase = await getClient()
     const userId = await getCurrentUserId(supabase)
     const { data, error } = await supabase
       .from(TABLE)
@@ -100,8 +105,8 @@ export async function readProject(id) {
 // Update a project by ID (name, etc.). Returns updated row.
 export async function updateProject(id, data) {
   if (!id) throw new Error('id required')
-  try {
-    const supabase = getClient()
+    try {
+      const supabase = await getClient()
     const userId = await getCurrentUserId(supabase)
 
     // If name is changing, enforce per-user uniqueness
@@ -136,8 +141,8 @@ export async function updateProject(id, data) {
 // Delete a project by ID.
 export async function deleteProject(id) {
   if (!id) throw new Error('id required')
-  try {
-    const supabase = getClient()
+    try {
+      const supabase = await getClient()
     const userId = await getCurrentUserId(supabase)
     const { error } = await supabase
       .from(TABLE)

--- a/src/utils/supabaseClient.js
+++ b/src/utils/supabaseClient.js
@@ -4,10 +4,10 @@ const url = import.meta.env.VITE_SUPABASE_URL
 const key = import.meta.env.VITE_SUPABASE_ANON_KEY
 
 if (!url) {
-  console.warn('VITE_SUPABASE_URL is not defined')
+  throw new Error('VITE_SUPABASE_URL is not defined')
 }
 if (!key) {
-  console.warn('VITE_SUPABASE_ANON_KEY is not defined')
+  throw new Error('VITE_SUPABASE_ANON_KEY is not defined')
 }
 
 export const supabase = createClient(url, key)


### PR DESCRIPTION
## Summary
- throw descriptive errors when Supabase env vars are missing
- dynamically load Supabase client and handle initialization errors in app startup
- lazily import Supabase in auth and repositories to surface missing client errors gracefully

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68995240b1648321a02e7d40af5b05a2