### PR TITLE
refactor: remove duplicate underline extension

### DIFF
--- a/src/components/ScriptEditor.jsx
+++ b/src/components/ScriptEditor.jsx
@@ -2,7 +2,6 @@ import { useEffect, useMemo, useRef, forwardRef, useImperativeHandle } from 'rea
 import { EditorContent, useEditor } from '@tiptap/react'
 import { BubbleMenu } from '@tiptap/react/menus'
 import StarterKit from '@tiptap/starter-kit'
-import Underline from '@tiptap/extension-underline'
 
 // Custom extensions / nodes
 import SlashCommand from '../extensions/SlashCommand'
@@ -48,7 +47,6 @@ const ScriptEditor = forwardRef(function ScriptEditor(
     StarterKit.configure({
       history: true,
     }),
-    Underline,
     // Custom nodes in your schema
     PageHeader,
     PanelHeader,


### PR DESCRIPTION
## Summary
- ensure only one underline extension is registered by relying on StarterKit's built-in underline

## Testing
- `npm test`
- `npm run lint` *(fails: getClient unused; supabase not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68995678262483218049cdc652f1b735