### PR TITLE
fix: import BubbleMenu from root package

### DIFF
--- a/src/components/ScriptEditor.jsx
+++ b/src/components/ScriptEditor.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, forwardRef, useImperativeHandle } from 'react'
 import { EditorContent, useEditor } from '@tiptap/react'
-import { BubbleMenu } from '@tiptap/react/menus'
+import { BubbleMenu } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import Underline from '@tiptap/extension-underline'
 


### PR DESCRIPTION
## Summary
- import `BubbleMenu` from `@tiptap/react`

## Testing
- `npm test`
- `npm run lint` *(fails: no-unused-vars in src/utils/auth.js)*
- `nohup npm run dev >/tmp/dev.log 2>&1 &`

------
https://chatgpt.com/codex/tasks/task_e_68995678c9088321a495a44f26201853