### PR TITLE
Optimize auth lookups with cached unauthenticated flag

### DIFF
--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -1,15 +1,6 @@
 import { clearCachedUserId } from './authCache.js'
 import { logger } from './logger.js'
-
-async function getClient() {
-  try {
-    const { supabase } = await import('./supabaseClient.js')
-    return supabase
-  } catch (error) {
-    console.error('Failed to load Supabase client:', error?.message || error)
-    throw error
-  }
-}
+import { supabase } from './supabaseClient.js'
 
 export async function signUp(email, password) {
   logger.log('Attempting signUp for', email)

--- a/src/utils/authCache.js
+++ b/src/utils/authCache.js
@@ -1,7 +1,9 @@
 let cachedUserId = null
+let checkedUnauthenticated = false
 
 export async function getCurrentUserId(supabase) {
   if (cachedUserId) return cachedUserId
+  if (checkedUnauthenticated) return null
   const {
     data: { user },
     error,
@@ -12,12 +14,19 @@ export async function getCurrentUserId(supabase) {
   }
   if (!user) {
     cachedUserId = null
+    checkedUnauthenticated = true
     return null
   }
   cachedUserId = user.id
+  checkedUnauthenticated = false
   return cachedUserId
 }
 
 export function clearCachedUserId() {
   cachedUserId = null
+  checkedUnauthenticated = false
+}
+
+export function isUnauthenticated() {
+  return checkedUnauthenticated
 }

--- a/src/utils/pageRepository.js
+++ b/src/utils/pageRepository.js
@@ -1,6 +1,6 @@
 // utils/pageRepository.js
 import { supabase } from './supabaseClient'
-import { getCurrentUserId } from './authCache'
+import { getCurrentUserId, isUnauthenticated } from './authCache'
 import { handleUnauthorized } from './session'
 
 const TABLE = 'pages'
@@ -23,6 +23,7 @@ function getClient() {
 
 // List pages for a project (returns [{ id, title }])
 export async function listPages(projectId) {
+  if (isUnauthenticated()) return []
   try {
     const supabase = getClient()
     const userId = await getCurrentUserId(supabase)
@@ -47,6 +48,7 @@ export async function listPages(projectId) {
 
 // Create a page; returns new page id.
 export async function createPage(name, data, projectId) {
+  if (isUnauthenticated()) return null
   try {
     const supabase = getClient()
     const now = new Date().toISOString()
@@ -80,6 +82,7 @@ export async function readPage(id, projectId) {
   if (!id) throw new Error('id required')
   if (!projectId) throw new Error('projectId required')
 
+  if (isUnauthenticated()) return null
   try {
     const supabase = getClient()
     const userId = await getCurrentUserId(supabase)
@@ -116,9 +119,11 @@ export async function updatePage(id, data, projectId) {
   if (!id) throw new Error('id required')
   if (!projectId) throw new Error('projectId required')
 
-    try {
-      const supabase = await getClient()
-      const existing = await readPage(id, projectId)
+  if (isUnauthenticated()) return null
+
+  try {
+    const supabase = await getClient()
+    const existing = await readPage(id, projectId)
     if (!existing) return null
 
     const updated = {
@@ -162,6 +167,7 @@ export async function deletePage(id, projectId) {
   if (!id) throw new Error('id required')
   if (!projectId) throw new Error('projectId required')
 
+  if (isUnauthenticated()) return false
   try {
     const supabase = getClient()
     const userId = await getCurrentUserId(supabase)

--- a/src/utils/projectRepository.js
+++ b/src/utils/projectRepository.js
@@ -1,6 +1,6 @@
 // utils/projectRepository.js
 import { supabase } from './supabaseClient'
-import { getCurrentUserId } from './authCache'
+import { getCurrentUserId, isUnauthenticated } from './authCache'
 import { handleUnauthorized } from './session'
 
 const TABLE = 'projects'
@@ -11,6 +11,7 @@ function getClient() {
 
 // List all projects for the current user.
 export async function listProjects() {
+  if (isUnauthenticated()) return []
   try {
     const supabase = getClient()
     const userId = await getCurrentUserId(supabase)
@@ -31,8 +32,9 @@ export async function listProjects() {
 
 // Create a new project (enforces unique name per user).
 export async function createProject(name, data = {}) {
-    try {
-      const supabase = await getClient()
+  if (isUnauthenticated()) return null
+  try {
+    const supabase = await getClient()
     const now = new Date().toISOString()
     const userId = await getCurrentUserId(supabase)
     if (!userId) return null
@@ -73,8 +75,9 @@ export async function createProject(name, data = {}) {
 // Read a project by ID (scoped to current user).
 export async function readProject(id) {
   if (!id) throw new Error('id required')
-    try {
-      const supabase = await getClient()
+  if (isUnauthenticated()) return null
+  try {
+    const supabase = await getClient()
     const userId = await getCurrentUserId(supabase)
     if (!userId) return null
     const { data, error } = await supabase
@@ -95,8 +98,9 @@ export async function readProject(id) {
 // Update a project by ID (name, etc.). Returns updated row.
 export async function updateProject(id, data) {
   if (!id) throw new Error('id required')
-    try {
-      const supabase = await getClient()
+  if (isUnauthenticated()) return null
+  try {
+    const supabase = await getClient()
     const userId = await getCurrentUserId(supabase)
     if (!userId) return null
 
@@ -132,8 +136,9 @@ export async function updateProject(id, data) {
 // Delete a project by ID.
 export async function deleteProject(id) {
   if (!id) throw new Error('id required')
-    try {
-      const supabase = await getClient()
+  if (isUnauthenticated()) return false
+  try {
+    const supabase = await getClient()
     const userId = await getCurrentUserId(supabase)
     if (!userId) return false
     const { error } = await supabase


### PR DESCRIPTION
## Summary
- Cache unauthenticated state in `getCurrentUserId` and expose `isUnauthenticated`
- Reset auth cache on sign-in/out and short-circuit repository queries when no user is present
- Switch auth utility to static Supabase import

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899576ed9a88321b600744b862d1332