### PR TITLE
Remove bubble menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1496,24 +1496,6 @@
         "@tiptap/core": "^3.0.9"
       }
     },
-    "node_modules/@tiptap/extension-bubble-menu": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.0.9.tgz",
-      "integrity": "sha512-fZQfdSbKJl3J+Yi+s8NrcLBgXHOaGVD4g+vn+orTPUlZdG9FWvEoon8DexOdK9OvYnW6QMM7kS8whOgpogVyUQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@floating-ui/dom": "^1.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "^3.0.9",
-        "@tiptap/pm": "^3.0.9"
-      }
-    },
     "node_modules/@tiptap/extension-bullet-list": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.0.9.tgz",
@@ -1843,7 +1825,6 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "optionalDependencies": {
-        "@tiptap/extension-bubble-menu": "^3.0.9",
         "@tiptap/extension-floating-menu": "^3.0.9"
       },
       "peerDependencies": {

--- a/src/components/ScriptEditor.jsx
+++ b/src/components/ScriptEditor.jsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useRef, forwardRef, useImperativeHandle } from 'react'
 import { EditorContent, useEditor } from '@tiptap/react'
-import { BubbleMenu } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 
 // Custom extensions / nodes
@@ -120,24 +119,6 @@ const ScriptEditor = forwardRef(function ScriptEditor(
         transform: `scale(${zoom})`,
       }}
     >
-      {editor && (
-        <BubbleMenu editor={editor} tippyOptions={{ duration: 100 }}>
-          {/* Keep your existing buttons; example for underline */}
-          <button
-            className={`btn ${editor.isActive('underline') ? 'active' : ''}`}
-            onClick={() =>
-              editor
-                .chain()
-                .focus(undefined, { scrollIntoView: false })
-                .toggleUnderline()
-                .run()
-            }
-            type="button"
-          >
-            U
-          </button>
-        </BubbleMenu>
-      )}
       <EditorContent editor={editor} className="editor-content" />
     </div>
   )

--- a/src/index.css
+++ b/src/index.css
@@ -301,15 +301,6 @@ body {
 }
 
 /* ScriptEditor */
-.editor-bubble-menu {
-  display: flex;
-  gap: 0.25rem;
-  border: 1px solid var(--border-color);
-  background: var(--bg-panel);
-  padding: 0.25rem;
-  border-radius: var(--radius);
-}
-
 .editor-wrapper {
   overscroll-behavior: contain;
   touch-action: pan-y;


### PR DESCRIPTION
## Summary
- remove TipTap BubbleMenu from ScriptEditor and delete associated CSS
- drop @tiptap/extension-bubble-menu from lock file

## Testing
- `npm test`
- `npm run lint` *(fails: 'getClient' is not defined, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689959d39af88321977d74df010fca4a